### PR TITLE
gitignore bin/ recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.next
 release.properties
-/bin
+bin/


### PR DESCRIPTION
I am not sure when the bin/ directory is created, but this way it works for mustang/ as well.