### PR TITLE
fix validation error, file specification not associated with an object

### DIFF
--- a/pdfa3-sample/src/main/java/pdfbox/PDFA3FileAttachment.java
+++ b/pdfa3-sample/src/main/java/pdfbox/PDFA3FileAttachment.java
@@ -30,6 +30,7 @@ import org.apache.jempbox.xmp.XMPSchemaBasic;
 import org.apache.jempbox.xmp.XMPSchemaDublinCore;
 import org.apache.jempbox.xmp.XMPSchemaPDF;
 import org.apache.jempbox.xmp.pdfa.XMPSchemaPDFAId;
+import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
@@ -120,6 +121,10 @@ public class PDFA3FileAttachment
     // cosArray.add(fs);
     // catalog.setItem("AF", cosArray);
 
+    COSDictionary dict2 = catalog.getCOSDictionary();
+    COSArray array = new COSArray();
+    array.add(fs.getCOSDictionary()); // see below
+    dict2.setItem("AF",array);
   }
 
   /**


### PR DESCRIPTION
PDFA3FileAttachment.pdf does not conform to PDF/A.

Validate PDF/A 3-a File online at http://www.pdf-tools.com/pdf/validate-pdfa-online.aspx

I found how to solve the problem at https://www.mail-archive.com/search?l=users@pdfbox.apache.org&q=subject:%22How+can+I+embed+files+in+PDF%2FA-3a%3F%22&o=newest&f=1

I hope you find it useful