### PR TITLE
Switched to ZUGFeRD XML generation via JAXB

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As dependency use this
 <dependency>
   <groupId>org.mustangproject.ZUGFeRD</groupId>
   <artifactId>mustang</artifactId>
-  <version>1.1.2</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 

--- a/mustang/pom.xml
+++ b/mustang/pom.xml
@@ -1,52 +1,60 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.github.rayman2200</groupId>
-		<artifactId>mustang-sample-project</artifactId>
-		<version>1.2.1-SNAPSHOT</version>
-	</parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.rayman2200</groupId>
+        <artifactId>mustang-sample-project</artifactId>
+        <version>1.2.1-SNAPSHOT</version>
+    </parent>
 
-	<groupId>org.mustangproject.ZUGFeRD</groupId>
-	<artifactId>mustang</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    <groupId>org.mustangproject.ZUGFeRD</groupId>
+    <artifactId>mustang</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-	<name>Mustang</name>
-	<description>The Mustang project is a java library to read and write ZUGFeRD meta data inside your invoice PDFs</description>
-	<url>http://www.mustangproject.org/</url>
+    <name>Mustang</name>
+    <description>The Mustang project is a java library to read and write ZUGFeRD meta data inside your invoice PDFs</description>
+    <url>http://www.mustangproject.org/</url>
 
-	<mailingLists>
-		<mailingList>
-			<name>User List</name>
-			<archive>https://groups.google.com/forum/?hl=de#!forum/mustangproject</archive>
-		</mailingList>
-	</mailingLists>
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+    </dependencies>
 
-	<licenses>
-		<license>
-			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-			<comments>A business-friendly OSS license</comments>
-		</license>
-	</licenses>
+    <mailingLists>
+        <mailingList>
+            <name>User List</name>
+            <archive>https://groups.google.com/forum/?hl=de#!forum/mustangproject</archive>
+        </mailingList>
+    </mailingLists>
 
-	<developers>
-		<developer>
-			<name>Jochen Stärk</name>
-			<email>jstaerk@usegroup.de</email>
-				<roles>
-					<role>architect</role>
-					<role>developer</role>
-				</roles>
-		</developer>
-                <developer>
-			<name>Alexander Schmidt</name>
-			<email>schmidt.alexander@mail.de</email>
-				<roles>
-					<role>developer</role>
-				</roles>
-		</developer>
-	</developers>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jochen Stärk</name>
+            <email>jstaerk@usegroup.de</email>
+            <roles>
+                <role>architect</role>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Alexander Schmidt</name>
+            <email>schmidt.alexander@mail.de</email>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
 
 </project>

--- a/mustang/pom.xml
+++ b/mustang/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.mustangproject.ZUGFeRD</groupId>
 	<artifactId>mustang</artifactId>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Mustang</name>
@@ -37,6 +37,13 @@
 			<email>jstaerk@usegroup.de</email>
 				<roles>
 					<role>architect</role>
+					<role>developer</role>
+				</roles>
+		</developer>
+                <developer>
+			<name>Alexander Schmidt</name>
+			<email>schmidt.alexander@mail.de</email>
+				<roles>
 					<role>developer</role>
 				</roles>
 		</developer>

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
@@ -119,6 +119,24 @@ public interface IZUGFeRDExportableTransaction {
 	 */
 	Date getDeliveryDate();
 	
-	
+        /**
+	 * get main invoice currency used on the invoice
+	 * @return
+	 */        
+        String getInvoiceCurrency();
+        
+        /**
+	 * get payment information text. e.g. Bank transfer
+	 * @return
+	 */  	
+        String getOwnPaymentInfoText();
+
+        /**
+	 * get payment term descriptional text
+         * e.g. Bis zum 22.10.2015 ohne Abzug
+	 * @return
+	 */         
+        String getPaymentTermDescription();
+        
 	
 }

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -1,24 +1,35 @@
 package org.mustangproject.ZUGFeRD;
+
 /**
- * Mustangproject's ZUGFeRD implementation
- * ZUGFeRD exporter
- * Licensed under the APLv2
+ * Mustangproject's ZUGFeRD implementation ZUGFeRD exporter Licensed under the
+ * APLv2
+ *
  * @date 2014-07-12
  * @version 1.1
  * @author jstaerk
- * */
-
-
+ *
+ */
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
 
 import javax.xml.transform.TransformerException;
 
@@ -40,663 +51,827 @@ import org.apache.pdfbox.pdmodel.common.COSObjectable;
 import org.apache.pdfbox.pdmodel.common.PDMetadata;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
-
-
+import org.mustangproject.ZUGFeRD.model.*;
 
 public class ZUGFeRDExporter {
-	/***
-	 * You will need Apache PDFBox. To use the ZUGFeRD exporter,
-	   implement IZUGFeRDExportableTransaction in yourTransaction
-	   (which will require you to implement Product, Item and Contact)
-	 then call
-	 			doc = PDDocument.load(PDFfilename);
-			// automatically add Zugferd to all outgoing invoices
-			ZUGFeRDExporter ze = new ZUGFeRDExporter();
-			ze.PDFmakeA3compliant(doc, "Your application name",
-					System.getProperty("user.name"), true);
-			ze.PDFattachZugferdFile(doc, yourTransaction);
 
-			doc.save(PDFfilename);
+    /**
+     * *
+     * You will need Apache PDFBox. To use the ZUGFeRD exporter, implement
+     * IZUGFeRDExportableTransaction in yourTransaction (which will require you
+     * to implement Product, Item and Contact) then call doc =
+     * PDDocument.load(PDFfilename); // automatically add Zugferd to all
+     * outgoing invoices ZUGFeRDExporter ze = new ZUGFeRDExporter();
+     * ze.PDFmakeA3compliant(doc, "Your application name",
+     * System.getProperty("user.name"), true); ze.PDFattachZugferdFile(doc,
+     * yourTransaction);
+     *
+     * doc.save(PDFfilename);
+     *
+     * @author jstaerk
+     *
+     */
+    public ZUGFeRDExporter() throws JAXBException {
+        jaxbContext = JAXBContext.newInstance("org.mustangproject.ZUGFeRD.model");
+        marshaller = jaxbContext.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        marshaller.setProperty("jaxb.encoding", "UTF-8");
+    }
 
-	 * @author jstaerk
-	 *
-	 */
+    private class LineCalc {
 
+        private IZUGFeRDExportableItem currentItem = null;
+        private BigDecimal totalGross;
+        private BigDecimal itemTotalNetAmount;
+        private BigDecimal itemTotalVATAmount;
 
-	
-	private class LineCalc {
-		private IZUGFeRDExportableItem currentItem=null;
-		private BigDecimal totalGross;
-		private BigDecimal itemTotalNetAmount;
-		private BigDecimal itemTotalVATAmount;
-		
-		public LineCalc(IZUGFeRDExportableItem currentItem) {
-			this.currentItem=currentItem;
-			BigDecimal multiplicator=currentItem.getProduct().getVATPercent().divide(new BigDecimal(100)).add(new BigDecimal(1));
+        public LineCalc(IZUGFeRDExportableItem currentItem) {
+            this.currentItem = currentItem;
+            BigDecimal multiplicator = currentItem.getProduct().getVATPercent().divide(new BigDecimal(100)).add(new BigDecimal(1));
 //			priceGross=currentItem.getPrice().multiply(multiplicator);
-			totalGross=currentItem.getPrice().multiply(multiplicator).multiply(currentItem.getQuantity());
-			itemTotalNetAmount=currentItem.getQuantity().multiply(currentItem.getPrice()).setScale(2,BigDecimal.ROUND_HALF_UP);
-			itemTotalVATAmount=totalGross.subtract(itemTotalNetAmount);
-		}
-
-		public BigDecimal getItemTotalNetAmount() {
-			return itemTotalNetAmount;
-		}
-
-		public BigDecimal getItemTotalVATAmount() {
-			return itemTotalVATAmount;
-		}
-
-	}
-
-
-
-	//// MAIN CLASS
-
-	private String conformanceLevel = "U";
-	private String versionStr       = "1.2.0";
-
-	// BASIC, COMFORT etc - may be set from outside.
-	private String ZUGFeRDConformanceLevel = null;
-
-
-	/**
-	 * Data (XML invoice) to be added to the ZUGFeRD PDF. It may be externally set, in which case passing a
-	 * IZUGFeRDExportableTransaction is not necessary. By default it is null meaning the caller needs to
-	 * pass a IZUGFeRDExportableTransaction for the XML to be populated.
-	 */
-	byte[] zugferdData = null;
-	private boolean isTest;
-	IZUGFeRDExportableTransaction trans=null;
-	
-	
-	private String nDigitFormat(BigDecimal value, int scale) {
-		/*
-		 * I needed 123,45, locale independent.I tried
-		 * NumberFormat.getCurrencyInstance().format( 12345.6789 ); but that is
-		 * locale specific.I also tried DecimalFormat df = new DecimalFormat(
-		 * "0,00" ); df.setDecimalSeparatorAlwaysShown(true);
-		 * df.setGroupingUsed(false); DecimalFormatSymbols symbols = new
-		 * DecimalFormatSymbols(); symbols.setDecimalSeparator(',');
-		 * symbols.setGroupingSeparator(' ');
-		 * df.setDecimalFormatSymbols(symbols);
-		 *
-		 * but that would not switch off grouping. Although I liked very much
-		 * the (incomplete) "BNF diagram" in
-		 * http://docs.oracle.com/javase/tutorial/i18n/format/decimalFormat.html
-		 * in the end I decided to calculate myself and take eur+sparator+cents
-		 *
-		 * This function will cut off, i.e. floor() subcent values Tests:
-		 * System.err.println(utils.currencyFormat(new BigDecimal(0),
-		 * ".")+"\n"+utils.currencyFormat(new BigDecimal("-1.10"),
-		 * ",")+"\n"+utils.currencyFormat(new BigDecimal("-1.1"),
-		 * ",")+"\n"+utils.currencyFormat(new BigDecimal("-1.01"),
-		 * ",")+"\n"+utils.currencyFormat(new BigDecimal("20000123.3489"),
-		 * ",")+"\n"+utils.currencyFormat(new BigDecimal("20000123.3419"),
-		 * ",")+"\n"+utils.currencyFormat(new BigDecimal("12"), ","));
-		 *
-		 * results 0.00 -1,10 -1,10 -1,01 20000123,34 20000123,34 12,00
-		 */
-		value=value.setScale( scale, BigDecimal.ROUND_HALF_UP ); // first, round so that e.g. 1.189999999999999946709294817992486059665679931640625 becomes 1.19
-		char[] repeat = new char[scale];
-		Arrays.fill(repeat, '0');
-		
-		DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols();
-		otherSymbols.setDecimalSeparator('.');
-		DecimalFormat dec = new DecimalFormat("0."+new String(repeat), otherSymbols);
-		return dec.format(value);
-		
-	}
-
-	private String vatFormat(BigDecimal value) {
-		return nDigitFormat(value, 2);
-	}
-
-	private String currencyFormat(BigDecimal value) {
-		return nDigitFormat(value, 2);
-	}
-
-	private String priceFormat(BigDecimal value) {
-		return nDigitFormat(value, 4);
-	}
-	private String quantityFormat(BigDecimal value) {
-		return nDigitFormat(value, 4);
-	}
-
-	/**
-	 	 All files are PDF/A-3, setConformance refers to the level conformance.
-
-	 	 PDF/A-3 has three coformance levels, called "A", "U" and "B".
-
-		 PDF/A-3-B where B means only visually
-		 preservable, U -standard for Mustang- means visually and unicode
-		 preservable and A means full compliance, i.e. visually,
-		 unicode and structurally preservable and tagged PDF, i.e. useful metainformation for blind people.
-
-		 Feel free to pass "A" as new level if you know what you are doing :-)
-
-
-	 */
-	public void setConformanceLevel(String newLevel) {
-		conformanceLevel=newLevel;
-	}
-
-	/**
-	 * enables the flag to indicate a test invoice in the XML structure
-	 * */
-	public void setTest() {
-		isTest=true;
-	}
-
-	/**
-	 * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on
-	 * the metadata level, this will not e.g. convert graphics to JPG-2000)
-	 * */
-	public PDDocumentCatalog PDFmakeA3compliant(PDDocument doc, String producer, String creator,
-			boolean attachZugferdHeaders) throws IOException,
-			TransformerException {
-		String fullProducer=producer + " (via mustangproject.org " + versionStr + ")";
-		PDDocumentCatalog cat = doc.getDocumentCatalog();
-		PDMetadata metadata = new PDMetadata(doc);
-		cat.setMetadata(metadata);
-		// we're using the jempbox org.apache.jempbox.xmp.XMPMetadata version,
-		// not the xmpbox one
-		XMPMetadata xmp = new XMPMetadata();
-
-		XMPSchemaPDFAId pdfaid = new XMPSchemaPDFAId(xmp);
-		pdfaid.setAbout(""); //$NON-NLS-1$
-		xmp.addSchema(pdfaid);
-
-		XMPSchemaDublinCore dc = xmp.addDublinCoreSchema();
-		dc.addCreator(creator);
-		dc.setAbout(""); //$NON-NLS-1$
-
-		XMPSchemaBasic xsb = xmp.addBasicSchema();
-		xsb.setAbout(""); //$NON-NLS-1$
-
-		xsb.setCreatorTool(creator);
-		xsb.setCreateDate(GregorianCalendar.getInstance());
-		// PDDocumentInformation pdi=doc.getDocumentInformation();
-		PDDocumentInformation pdi = new PDDocumentInformation();
-		pdi.setProducer(fullProducer);
-		pdi.setAuthor(creator);
-		doc.setDocumentInformation(pdi);
-
-		XMPSchemaPDF pdf = xmp.addPDFSchema();
-		pdf.setProducer(fullProducer);
-		pdf.setAbout(""); //$NON-NLS-1$
-
-		/*
-		// Mandatory: PDF/A3-a is tagged PDF which has to be expressed using a
-		// MarkInfo dictionary (PDF A/3 Standard sec. 6.7.2.2)
-		PDMarkInfo markinfo = new PDMarkInfo();
-		markinfo.setMarked(true);
-		doc.getDocumentCatalog().setMarkInfo(markinfo);
-*/
-/*
- *
-		To be on the safe side, we use level B without Markinfo because we can not
-		guarantee that the user  correctly tagged the templates for the PDF.
-
- * */
-		pdfaid.setConformance(conformanceLevel);//$NON-NLS-1$ //$NON-NLS-1$
-
-		pdfaid.setPart(3);
-
-		if (attachZugferdHeaders) {
-			addZugferdXMP(xmp); /*
-								 * this is the only line where we do something
-								 * Zugferd-specific, i.e. add PDF metadata
-								 * specifically for Zugferd, not generically for
-								 * a embedded file
-								 */
-		}
-
-		metadata.importXMPMetadata(xmp);
-		return cat;
-	}
-
-	private String getZugferdXMLForTransaction(IZUGFeRDExportableTransaction trans) {
-		this.trans=trans;
-	
-		SimpleDateFormat germanDateFormat = new SimpleDateFormat("dd.MM.yyyy"); //$NON-NLS-1$
-		SimpleDateFormat zugferdDateFormat = new SimpleDateFormat("yyyyMMdd"); //$NON-NLS-1$
-		String testBooleanStr="false";
-		if (isTest) {
-			testBooleanStr="true";
-			
-		}
-		String senderReg="";
-		if (trans.getOwnOrganisationFullPlaintextInfo()!=null) {
-		 senderReg=""
-					+ "<ram:IncludedNote>\n"
-					+ "		<ram:Content>\n"
-					+ trans.getOwnOrganisationFullPlaintextInfo()
-					+ "		</ram:Content>\n"
-					+ "<ram:SubjectCode>REG</ram:SubjectCode>\n"
-					+ "</ram:IncludedNote>\n";
-			
-		}
-		String xml= "﻿<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
-
-				+ "<rsm:CrossIndustryDocument xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:rsm=\"urn:ferd:CrossIndustryDocument:invoice:1p0\""
-//				+ " xsi:schemaLocation=\"urn:ferd:CrossIndustryDocument:invoice:1p0 ../Schema/ZUGFeRD1p0.xsd\""
-				+ " xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12\""
-				+ " xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15\">\n" //$NON-NLS-1$
-				+ "	<rsm:SpecifiedExchangedDocumentContext>\n" //$NON-NLS-1$
-				+ "		<ram:TestIndicator><udt:Indicator>"+testBooleanStr+"</udt:Indicator></ram:TestIndicator>\n" //$NON-NLS-1$
-				+ "		<ram:GuidelineSpecifiedDocumentContextParameter>\n" //$NON-NLS-1$
-				+ "			<ram:ID>urn:ferd:CrossIndustryDocument:invoice:1p0:comfort</ram:ID>\n" //$NON-NLS-1$
-				+ "		</ram:GuidelineSpecifiedDocumentContextParameter>\n" //$NON-NLS-1$
-				+ "	</rsm:SpecifiedExchangedDocumentContext>\n" //$NON-NLS-1$
-				+ "	<rsm:HeaderExchangedDocument>\n" //$NON-NLS-1$
-				+ "		<ram:ID>"+trans.getNumber()+"</ram:ID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "		<ram:Name>RECHNUNG</ram:Name>\n" //$NON-NLS-1$
-				+ "		<ram:TypeCode>380</ram:TypeCode>\n" //$NON-NLS-1$
-				+ "		<ram:IssueDateTime><udt:DateTimeString format=\"102\">"+zugferdDateFormat.format(trans.getIssueDate())+"</udt:DateTimeString></ram:IssueDateTime>\n" //date format was 20130605 //$NON-NLS-1$ //$NON-NLS-2$
-				+ senderReg
-//				+ "		<IncludedNote>\n"
-//				+ "			<Content>\n"
-//				+ "Rechnung gemäß Bestellung Nr. 2013-471331 vom 01.03.2013.\n"
-//				+ "\n"
-//				+ "      </Content>\n"
-//				+ "      </IncludedNote>\n"
-//				+ "      <IncludedNote>\n"
-//				+ "			<Content>\n"
-//				+ "Es bestehen Rabatt- und Bonusvereinbarungen.\n"
-//				+ "			</Content>\n"
-//				+ "			<SubjectCode>AAK</SubjectCode>\n"
-//				+ "		</IncludedNote>\n"
-				+ "	</rsm:HeaderExchangedDocument>\n" //$NON-NLS-1$
-				+ "	<rsm:SpecifiedSupplyChainTradeTransaction>\n" //$NON-NLS-1$
-				+ "		<ram:ApplicableSupplyChainTradeAgreement>\n" //$NON-NLS-1$
-//				+ "			<BuyerReference>AB-312</BuyerReference>\n"
-				+ "			<ram:SellerTradeParty>\n" //$NON-NLS-1$
-//				+ "				<GlobalID schemeID=\"0088\">4000001123452</GlobalID>\n"
-				+ "				<ram:Name>"+trans.getOwnOrganisationName()+"</ram:Name>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				<ram:PostalTradeAddress>\n"
-				+ "					<ram:PostcodeCode>"+trans.getOwnZIP()+"</ram:PostcodeCode>\n"
-				+ "					<ram:LineOne>"+trans.getOwnStreet()+"</ram:LineOne>\n"
-				+ "					<ram:CityName>"+trans.getOwnLocation()+"</ram:CityName>\n"
-				+ "					<ram:CountryID>"+trans.getOwnCountry()+"</ram:CountryID>\n"
-				+ "				</ram:PostalTradeAddress>\n"
-				+ "				<ram:SpecifiedTaxRegistration>\n" //$NON-NLS-1$
-				+ "					<ram:ID schemeID=\"FC\">"+trans.getOwnTaxID()+"</ram:ID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				</ram:SpecifiedTaxRegistration>\n" //$NON-NLS-1$
-				+ "				<ram:SpecifiedTaxRegistration>\n" //$NON-NLS-1$
-				+ "					<ram:ID schemeID=\"VA\">"+trans.getOwnVATID()+"</ram:ID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				</ram:SpecifiedTaxRegistration>\n" //$NON-NLS-1$
-				+ "			</ram:SellerTradeParty>\n" //$NON-NLS-1$
-				+ "			<ram:BuyerTradeParty>\n" //$NON-NLS-1$
-//				+ "				<ID>GE2020211</ID>\n"
-//				+ "				<GlobalID schemeID=\"0088\">4000001987658</GlobalID>\n"
-				+ "				<ram:Name>"+trans.getRecipient().getName()+"</ram:Name>\n" //$NON-NLS-1$ //$NON-NLS-2$
-//				+ "				<DefinedTradeContact>\n"
-//				+ "					<PersonName>xxx</PersonName>\n"
-//				+ "				</DefinedTradeContact>\n"
-				+ "				<ram:PostalTradeAddress>\n" //$NON-NLS-1$
-				+ "					<ram:PostcodeCode>"+trans.getRecipient().getZIP()+"</ram:PostcodeCode>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "					<ram:LineOne>"+trans.getRecipient().getStreet()+"</ram:LineOne>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "					<ram:CityName>"+trans.getRecipient().getLocation()+"</ram:CityName>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "					<ram:CountryID>"+trans.getRecipient().getCountry()+"</ram:CountryID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				</ram:PostalTradeAddress>\n" //$NON-NLS-1$
-				+ "				<ram:SpecifiedTaxRegistration>\n" //$NON-NLS-1$
-				+ "					<ram:ID schemeID=\"VA\">"+trans.getRecipient().getVATID()+"</ram:ID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				</ram:SpecifiedTaxRegistration>\n" //$NON-NLS-1$
-				+ "			</ram:BuyerTradeParty>\n" //$NON-NLS-1$
-//				+ "			<BuyerOrderReferencedDocument>\n"
-//				+ "				<IssueDateTime format=\"102\">20130301</IssueDateTime>\n"
-//				+ "			<ID>2013-471331</ID>\n"
-//				+ "			</BuyerOrderReferencedDocument>\n"
-				+ "		</ram:ApplicableSupplyChainTradeAgreement>\n" //$NON-NLS-1$
-				+ "		<ram:ApplicableSupplyChainTradeDelivery>\n"
-				+ "			<ram:ActualDeliverySupplyChainEvent>\n"
-				+ "				<ram:OccurrenceDateTime><udt:DateTimeString format=\"102\">"+zugferdDateFormat.format(trans.getDeliveryDate())+"</udt:DateTimeString></ram:OccurrenceDateTime>\n"
-				+ "			</ram:ActualDeliverySupplyChainEvent>\n"
-				/*
-				+ "			<DeliveryNoteReferencedDocument>\n"
-				+ "				<IssueDateTime format=\"102\">20130603</IssueDateTime>\n"
-				+ "				<ID>2013-51112</ID>\n"
-				+ "			</DeliveryNoteReferencedDocument>\n" */
-				+ "		</ram:ApplicableSupplyChainTradeDelivery>\n"
-				+ "		<ram:ApplicableSupplyChainTradeSettlement>\n" //$NON-NLS-1$
-				+ "			<ram:PaymentReference>"+trans.getNumber()+"</ram:PaymentReference>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "			<ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>\n" //$NON-NLS-1$
-				+ "			<ram:SpecifiedTradeSettlementPaymentMeans>\n" //$NON-NLS-1$
-				+ "				<ram:TypeCode>42</ram:TypeCode>\n" //$NON-NLS-1$
-				+ "				<ram:Information>Überweisung</ram:Information>\n" //$NON-NLS-1$
-				+ "				<ram:PayeePartyCreditorFinancialAccount>\n" //$NON-NLS-1$
-				+ "					<ram:IBANID>"+trans.getOwnIBAN()+"</ram:IBANID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				</ram:PayeePartyCreditorFinancialAccount>\n" //$NON-NLS-1$
-				+ "				<ram:PayeeSpecifiedCreditorFinancialInstitution>\n" //$NON-NLS-1$
-				+ "					<ram:BICID>"+trans.getOwnBIC()+"</ram:BICID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "					<ram:Name>"+trans.getOwnBankName()+"</ram:Name>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				</ram:PayeeSpecifiedCreditorFinancialInstitution>\n" //$NON-NLS-1$
-				+ "			</ram:SpecifiedTradeSettlementPaymentMeans>\n"; //$NON-NLS-1$
-
-
-		
-		HashMap<BigDecimal, VATAmount> VATPercentAmountMap=getVATPercentAmountMap();
-		for (BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
-			VATAmount amount = VATPercentAmountMap.get(currentTaxPercent);
-			if (amount != null) {
-				xml += "			<ram:ApplicableTradeTax>\n" //$NON-NLS-1$
-								+ "				<ram:CalculatedAmount currencyID=\"EUR\">"+currencyFormat(amount.getCalculated())+"</ram:CalculatedAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-								+ "				<ram:TypeCode>VAT</ram:TypeCode>\n" //$NON-NLS-1$
-								+ "				<ram:BasisAmount currencyID=\"EUR\">"+currencyFormat(amount.getBasis())+"</ram:BasisAmount>\n"
-								+ "				<ram:CategoryCode>S</ram:CategoryCode>\n" //$NON-NLS-1$
-								+ "				<ram:ApplicablePercent>"+vatFormat(currentTaxPercent)+"</ram:ApplicablePercent>\n" //$NON-NLS-1$
-								+ "			</ram:ApplicableTradeTax>\n"; //$NON-NLS-1$
-
-
-
-			}
-		}
-/*				xml+= "
-				+ "			<SpecifiedTradeAllowanceCharge>\n"
-				+ "				<ChargeIndicator>false</ChargeIndicator>\n"
-				+ "				<BasisAmount currencyID=\"EUR\">10</BasisAmount>\n"
-				+ "				<ActualAmount>1.00</ActualAmount>\n"
-				+ "				<Reason>Sondernachlass</Reason>\n"
-				+ "				<CategoryTradeTax>\n"
-				+ "					<TypeCode>VAT</TypeCode>\n"
-				+ "					<CategoryCode>S</CategoryCode>\n"
-				+ "					<ApplicablePercent>19</ApplicablePercent>\n"
-				+ "				</CategoryTradeTax>\n"
-				+ "			</SpecifiedTradeAllowanceCharge>\n"
-				+ "			<SpecifiedTradeAllowanceCharge>\n"
-				+ "				<ChargeIndicator>false</ChargeIndicator>\n"
-				+ "				<BasisAmount currencyID=\"EUR\">137.30</BasisAmount>\n"
-				+ "				<ActualAmount>13.73</ActualAmount>\n"
-				+ "				<Reason>Sondernachlass</Reason>\n"
-				+ "				<CategoryTradeTax>\n"
-				+ "					<TypeCode>VAT</TypeCode>\n"
-				+ "					<CategoryCode>S</CategoryCode>\n"
-				+ "					<ApplicablePercent>7</ApplicablePercent>\n"
-				+ "				</CategoryTradeTax>\n"
-				+ "							</SpecifiedTradeAllowanceCharge>\n"
-				+ "			<SpecifiedLogisticsServiceCharge>\n"
-				+ "				<Description>Versandkosten</Description>\n"
-				+ "				<AppliedAmount>5.80</AppliedAmount>\n"
-				+ "				<AppliedTradeTax>\n"
-				+ "					<TypeCode>VAT</TypeCode>\n"
-				+ "					<CategoryCode>S</CategoryCode>\n"
-				+ "					<ApplicablePercent>7</ApplicablePercent>\n"
-				+ "				</AppliedTradeTax>\n"
-				+ "			</SpecifiedLogisticsServiceCharge>\n"*/
-
-				xml=xml+ "			<ram:SpecifiedTradePaymentTerms>\n" //$NON-NLS-1$
-				+ "				<ram:Description>Zahlbar ohne Abzug bis "+germanDateFormat.format(trans.getDueDate())+"</ram:Description>\n"
-				+ "				<ram:DueDateDateTime><udt:DateTimeString format=\"102\">"+zugferdDateFormat.format(trans.getDueDate())+"</udt:DateTimeString></ram:DueDateDateTime>\n"//20130704 //$NON-NLS-1$ //$NON-NLS-2$
-				+ "			</ram:SpecifiedTradePaymentTerms>\n" //$NON-NLS-1$
-				+ "			<ram:SpecifiedTradeSettlementMonetarySummation>\n" //$NON-NLS-1$
-				+ "				<ram:LineTotalAmount currencyID=\"EUR\">"+currencyFormat(getTotal())+"</ram:LineTotalAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				<ram:ChargeTotalAmount currencyID=\"EUR\">0.00</ram:ChargeTotalAmount>\n" //$NON-NLS-1$
-				+ "				<ram:AllowanceTotalAmount currencyID=\"EUR\">0.00</ram:AllowanceTotalAmount>\n" //$NON-NLS-1$
-//				+ "				<ChargeTotalAmount currencyID=\"EUR\">5.80</ChargeTotalAmount>\n"
-//				+ "				<AllowanceTotalAmount currencyID=\"EUR\">14.73</AllowanceTotalAmount>\n"
-				+ "				<ram:TaxBasisTotalAmount currencyID=\"EUR\">"+currencyFormat(getTotal())+"</ram:TaxBasisTotalAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				<ram:TaxTotalAmount currencyID=\"EUR\">"+currencyFormat(getTotalGross().subtract(getTotal()))+"</ram:TaxTotalAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "				<ram:GrandTotalAmount currencyID=\"EUR\">"+currencyFormat(getTotalGross())+"</ram:GrandTotalAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-//				+ "				<TotalPrepaidAmount currencyID=\"EUR\">0.00</TotalPrepaidAmount>\n"
-				+ "				<ram:DuePayableAmount currencyID=\"EUR\">"+currencyFormat(getTotalGross())+"</ram:DuePayableAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-				+ "			</ram:SpecifiedTradeSettlementMonetarySummation>\n" //$NON-NLS-1$
-				+ "		</ram:ApplicableSupplyChainTradeSettlement>\n"; //$NON-NLS-1$
-//				+ "		<IncludedSupplyChainTradeLineItem>\n"
-//				+ "			<AssociatedDocumentLineDocument>\n"
-//				+ "				<IncludedNote>\n"
-//				+ "					<Content>Wir erlauben uns Ihnen folgende Positionen aus der Lieferung Nr. 2013-51112 in Rechnung zu stellen:</Content>\n"
-//				+ "				</IncludedNote>\n"
-//				+ "			</AssociatedDocumentLineDocument>\n"
-//				+ "		</IncludedSupplyChainTradeLineItem>\n";
-
-
-				int lineID=0;
-				for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
-					lineID++;
-
-					LineCalc lc=new LineCalc(currentItem);
-					xml=xml+ "		<ram:IncludedSupplyChainTradeLineItem>\n"+ //$NON-NLS-1$
-					"			<ram:AssociatedDocumentLineDocument>\n" //$NON-NLS-1$
-							+ "				<ram:LineID>"+lineID+"</ram:LineID>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "			</ram:AssociatedDocumentLineDocument>\n" //$NON-NLS-1$
-
-							+ "			<ram:SpecifiedSupplyChainTradeAgreement>\n" //$NON-NLS-1$
-							+ "				<ram:GrossPriceProductTradePrice>\n" //$NON-NLS-1$
-							+ "					<ram:ChargeAmount currencyID=\"EUR\">"+priceFormat(currentItem.getPrice())+"</ram:ChargeAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "					<ram:BasisQuantity unitCode=\""+currentItem.getProduct().getUnit()+"\">1.0000</ram:BasisQuantity>\n" //$NON-NLS-1$ //$NON-NLS-2$
-//							+ "					<AppliedTradeAllowanceCharge>\n"
-//							+ "						<ChargeIndicator>false</ChargeIndicator>\n"
-//							+ "						<ActualAmount currencyID=\"EUR\">0.6667</ActualAmount>\n"
-//							+ "						<Reason>Rabatt</Reason>\n"
-//							+ "					</AppliedTradeAllowanceCharge>\n"
-							+ "				</ram:GrossPriceProductTradePrice>\n" //$NON-NLS-1$
-							+ "				<ram:NetPriceProductTradePrice>\n" //$NON-NLS-1$
-							+ "					<ram:ChargeAmount currencyID=\"EUR\">"+priceFormat(currentItem.getPrice())+"</ram:ChargeAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "					<ram:BasisQuantity unitCode=\""+currentItem.getProduct().getUnit()+"\">1.0000</ram:BasisQuantity>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "				</ram:NetPriceProductTradePrice>\n" //$NON-NLS-1$
-							+ "			</ram:SpecifiedSupplyChainTradeAgreement>\n" //$NON-NLS-1$
-
-							+ "			<ram:SpecifiedSupplyChainTradeDelivery>\n" //$NON-NLS-1$
-							+ "				<ram:BilledQuantity unitCode=\""+currentItem.getProduct().getUnit()+"\">"+quantityFormat(currentItem.getQuantity())+"</ram:BilledQuantity>\n" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-							+ "			</ram:SpecifiedSupplyChainTradeDelivery>\n" //$NON-NLS-1$
-							+ "			<ram:SpecifiedSupplyChainTradeSettlement>\n" //$NON-NLS-1$
-							+ "				<ram:ApplicableTradeTax>\n" //$NON-NLS-1$
-							+ "					<ram:TypeCode>VAT</ram:TypeCode>\n" //$NON-NLS-1$
-							+ "					<ram:CategoryCode>S</ram:CategoryCode>\n" //$NON-NLS-1$
-							+ "					<ram:ApplicablePercent>"+vatFormat(currentItem.getProduct().getVATPercent())+"</ram:ApplicablePercent>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "				</ram:ApplicableTradeTax>\n" //$NON-NLS-1$
-							+ "				<ram:SpecifiedTradeSettlementMonetarySummation>\n" //$NON-NLS-1$
-							+ "					<ram:LineTotalAmount currencyID=\"EUR\">"+currencyFormat(lc.getItemTotalNetAmount())+"</ram:LineTotalAmount>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "				</ram:SpecifiedTradeSettlementMonetarySummation>\n" //$NON-NLS-1$
-							+ "			</ram:SpecifiedSupplyChainTradeSettlement>\n" //$NON-NLS-1$
-							+ "			<ram:SpecifiedTradeProduct>\n" //$NON-NLS-1$
-//							+ "				<GlobalID schemeID=\"0160\">4012345001235</GlobalID>\n"
-//							+ "				<SellerAssignedID>KR3M</SellerAssignedID>\n"
-//							+ "				<BuyerAssignedID>55T01</BuyerAssignedID>\n"
-							+ "				<ram:Name>"+currentItem.getProduct().getName()+"</ram:Name>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "				<ram:Description>"+currentItem.getProduct().getDescription()+"</ram:Description>\n" //$NON-NLS-1$ //$NON-NLS-2$
-							+ "			</ram:SpecifiedTradeProduct>\n" //$NON-NLS-1$
-							+ "		</ram:IncludedSupplyChainTradeLineItem>\n"; //$NON-NLS-1$
-
-
-
-				}
-
-
-				xml=xml	+ "	</rsm:SpecifiedSupplyChainTradeTransaction>\n" //$NON-NLS-1$
-				+ "</rsm:CrossIndustryDocument>"; //$NON-NLS-1$
-				return xml;
-	}
-
-
-	private BigDecimal getTotalGross() {
-		
-		BigDecimal res=getTotal();
-		HashMap<BigDecimal, VATAmount> VATPercentAmountMap=getVATPercentAmountMap();
-		for (BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
-			VATAmount amount = VATPercentAmountMap.get(currentTaxPercent);
-			res=res.add(amount.getCalculated()); 
-		}
-
-			
-		return res;
-	}
-
-	private BigDecimal getTotal() {
-		BigDecimal res=new BigDecimal(0);
-		for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
-			LineCalc lc=new LineCalc(currentItem);
-			res=res.add(lc.getItemTotalNetAmount());
-		}
-		return res;
-	}
-
-	/**
-	 * which taxes have been used with which amounts in this transaction,
-	 * empty for no taxes, or e.g. 19=>190 and 7=>14 if 1000 Eur were applicable
-	 * to 19% VAT (=>190 EUR VAT) and 200 EUR were applicable to 7% (=>14 EUR VAT)
-	 * 190 Eur  
-	 * @return
-	 *
-	*/
-	private HashMap<BigDecimal, VATAmount> getVATPercentAmountMap() {
-		HashMap<BigDecimal, VATAmount> hm=new HashMap<BigDecimal, VATAmount> ();
-		
-		for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
-			BigDecimal percent=currentItem.getProduct().getVATPercent();
-			LineCalc lc=new LineCalc(currentItem);
-			VATAmount itemVATAmount=new VATAmount(lc.getItemTotalNetAmount(), lc.getItemTotalVATAmount() ) ;
-			VATAmount current=hm.get(percent);
-			if (current==null) {
-				hm.put(percent, itemVATAmount);
-			} else {
-				hm.put(percent, current.add(itemVATAmount));
-				
-			}
-		}
-
-		return hm;
-	}
-
-	/**
-	 * Embeds the Zugferd XML structure in a file named ZUGFeRD-invoice.xml.
-	 *
-	 * @param doc PDDocument to attach an XML invoice to
-	 * @param trans a IZUGFeRDExportableTransaction that provides the data-model to populate the XML.
-	 *        This parameter may be null, if so the XML data should hav ebeen set via <code>setZUGFeRDXMLData(byte[] zugferdData)</code>
-	 */
-	public void PDFattachZugferdFile(PDDocument doc, IZUGFeRDExportableTransaction trans) throws IOException {
-
-		if (zugferdData == null) // XML ZUGFeRD data not set externally, needs to be built
-		{
-			// create a dummy file stream, this would probably normally be a
-			// FileInputStream
-
-			byte[] zugferdRaw = getZugferdXMLForTransaction(trans).getBytes("UTF-8"); //$NON-NLS-1$
-
-			if ((zugferdRaw[0]==(byte)0xEF)&&(zugferdRaw[1]==(byte)0xBB)&&(zugferdRaw[2]==(byte)0xBF)) {
-				// I don't like BOMs, lets remove it
-				zugferdData=new byte[zugferdRaw.length-3];
-				System.arraycopy(zugferdRaw,3,zugferdData,0,zugferdRaw.length-3);
-			}	else {
-				zugferdData=zugferdRaw;
-			}
-		}
-
-
-		PDFAttachGenericFile(doc, "ZUGFeRD-invoice.xml", "Alternative", "Invoice metadata conforming to ZUGFeRD standard (http://www.ferd-net.de/front_content.php?idcat=231&lang=4)", "text/xml", zugferdData);
-	}
-
-
-	/**
-	 * Embeds an external file (generic - any type allowed) in the PDF.
-	 *
-	 * @param doc PDDocument to attach the file to.
-	 * @param filename name of the file that will become attachment name in the PDF
-	 * @param relationship how the file relates to the content, e.g. "Alternative"
-	 * @param description Human-readable description of the file content
-	 * @param subType type of the data e.g. could be "text/xml" - mime like
-	 * @param data the binary data of the file/attachment
-	 */
-	public void PDFAttachGenericFile(PDDocument doc, String filename, String relationship, String description, String subType, byte[] data)
-		throws IOException
-	{
-		PDComplexFileSpecification fs = new PDComplexFileSpecification();
-		fs.setFile(filename);
-
-		COSDictionary dict = fs.getCOSDictionary();
-		dict.setName("AFRelationship", relationship);
-		dict.setString("UF", filename);
-		dict.setString("Desc", description);
-
-		ByteArrayInputStream fakeFile = new ByteArrayInputStream(data);
-		PDEmbeddedFile ef = new PDEmbeddedFile(doc, fakeFile);
-		ef.setSubtype(subType);
-		ef.setSize(data.length);
-		ef.setCreationDate(new GregorianCalendar());
-
-		ef.setModDate(GregorianCalendar.getInstance());
-
-		fs.setEmbeddedFile(ef);
-
-		// In addition make sure the embedded file is set under /UF
-		dict = fs.getCOSDictionary();
-		COSDictionary efDict = (COSDictionary)dict.getDictionaryObject(COSName.EF);
-		COSBase lowerLevelFile = efDict.getItem(COSName.F);
-		efDict.setItem(COSName.UF, lowerLevelFile);
-
-		// now add the entry to the embedded file tree and set in the document.
-		PDDocumentNameDictionary names = new PDDocumentNameDictionary(doc.getDocumentCatalog());
-		PDEmbeddedFilesNameTreeNode efTree = names.getEmbeddedFiles();
-		if (efTree == null)
-		{
-			efTree = new PDEmbeddedFilesNameTreeNode();
-		}
-
-		Map<String, COSObjectable> namesMap = new HashMap<String, COSObjectable>();
-		Map<String, COSObjectable> oldNamesMap = efTree.getNames();
-		if (oldNamesMap != null)
-		{
-			for (String key : oldNamesMap.keySet())
-			{
-				namesMap.put(key, oldNamesMap.get(key));
-			}
-		}
-		namesMap.put(filename, fs);
-		efTree.setNames(namesMap);
-
-		names.setEmbeddedFiles(efTree);
-		doc.getDocumentCatalog().setNames(names);
-
-		// AF entry (Array) in catalog with the FileSpec
-		COSArray cosArray = (COSArray)doc.getDocumentCatalog().getCOSDictionary().getItem("AF");
-		if (cosArray == null)
-		{
-			cosArray = new COSArray();
-		}
-		cosArray.add(fs);
-		doc.getDocumentCatalog().getCOSDictionary().setItem("AF", cosArray);
-	}
-
-
-	/**
-	 * Sets the ZUGFeRD XML data to be attached as a single byte array. This is useful for
-	 * use-cases where the XML has already been produced by some external API or component.
-	 *
-	 * @param zugferdData XML data to be set as a byte array (XML file in raw form).
-	 */
-	public void setZUGFeRDXMLData(byte[] zugferdData)
-	{
-		this.zugferdData = zugferdData;
-	}
-
-
-	/**
-	 * Sets the ZUGFeRD conformance level (override).
-	 *
-	 * @param ZUGFeRDConformanceLevel the new conformance level
-	 */
-	public void setZUGFeRDConformanceLevel(String ZUGFeRDConformanceLevel)
-	{
-		this.ZUGFeRDConformanceLevel = ZUGFeRDConformanceLevel;
-	}
-
-/***
- * This will add both the RDF-indication which embedded file is Zugferd and the
- * neccessary PDF/A schema extension description to be able to add this information to RDF
- * @param metadata
- */
-	private void addZugferdXMP(XMPMetadata metadata) {
-
-		XMPSchemaZugferd zf = new XMPSchemaZugferd(metadata, this.ZUGFeRDConformanceLevel);
-		zf.setAbout(""); //$NON-NLS-1$
-		metadata.addSchema(zf);
-
-		XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(metadata);
-		pdfaex.setAbout(""); //$NON-NLS-1$
-		metadata.addSchema(pdfaex);
-
-	}
+            totalGross = currentItem.getPrice().multiply(multiplicator).multiply(currentItem.getQuantity());
+            itemTotalNetAmount = currentItem.getQuantity().multiply(currentItem.getPrice()).setScale(2, BigDecimal.ROUND_HALF_UP);
+            itemTotalVATAmount = totalGross.subtract(itemTotalNetAmount);
+        }
+
+        public BigDecimal getItemTotalNetAmount() {
+            return itemTotalNetAmount;
+        }
+
+        public BigDecimal getItemTotalVATAmount() {
+            return itemTotalVATAmount;
+        }
+
+    }
+
+    //// MAIN CLASS
+    private String conformanceLevel = "U";
+    private String versionStr = "1.2.0";
+
+    // BASIC, COMFORT etc - may be set from outside.
+    private String ZUGFeRDConformanceLevel = null;
+
+    /**
+     * Data (XML invoice) to be added to the ZUGFeRD PDF. It may be externally
+     * set, in which case passing a IZUGFeRDExportableTransaction is not
+     * necessary. By default it is null meaning the caller needs to pass a
+     * IZUGFeRDExportableTransaction for the XML to be populated.
+     */
+    byte[] zugferdData = null;
+    private boolean isTest;
+    IZUGFeRDExportableTransaction trans = null;
+
+    private BigDecimal nDigitFormat(BigDecimal value, int scale) {
+        /*
+         * I needed 123,45, locale independent.I tried
+         * NumberFormat.getCurrencyInstance().format( 12345.6789 ); but that is
+         * locale specific.I also tried DecimalFormat df = new DecimalFormat(
+         * "0,00" ); df.setDecimalSeparatorAlwaysShown(true);
+         * df.setGroupingUsed(false); DecimalFormatSymbols symbols = new
+         * DecimalFormatSymbols(); symbols.setDecimalSeparator(',');
+         * symbols.setGroupingSeparator(' ');
+         * df.setDecimalFormatSymbols(symbols);
+         *
+         * but that would not switch off grouping. Although I liked very much
+         * the (incomplete) "BNF diagram" in
+         * http://docs.oracle.com/javase/tutorial/i18n/format/decimalFormat.html
+         * in the end I decided to calculate myself and take eur+sparator+cents
+         *
+         * This function will cut off, i.e. floor() subcent values Tests:
+         * System.err.println(utils.currencyFormat(new BigDecimal(0),
+         * ".")+"\n"+utils.currencyFormat(new BigDecimal("-1.10"),
+         * ",")+"\n"+utils.currencyFormat(new BigDecimal("-1.1"),
+         * ",")+"\n"+utils.currencyFormat(new BigDecimal("-1.01"),
+         * ",")+"\n"+utils.currencyFormat(new BigDecimal("20000123.3489"),
+         * ",")+"\n"+utils.currencyFormat(new BigDecimal("20000123.3419"),
+         * ",")+"\n"+utils.currencyFormat(new BigDecimal("12"), ","));
+         *
+         * results 0.00 -1,10 -1,10 -1,01 20000123,34 20000123,34 12,00
+         */
+        value = value.setScale(scale, BigDecimal.ROUND_HALF_UP); // first, round so that e.g. 1.189999999999999946709294817992486059665679931640625 becomes 1.19
+        char[] repeat = new char[scale];
+        Arrays.fill(repeat, '0');
+
+        DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols();
+        otherSymbols.setDecimalSeparator('.');
+        DecimalFormat dec = new DecimalFormat("0." + new String(repeat), otherSymbols);
+        return new BigDecimal(dec.format(value));
+
+    }
+
+    private BigDecimal vatFormat(BigDecimal value) {
+        return nDigitFormat(value, 2);
+    }
+
+    private BigDecimal currencyFormat(BigDecimal value) {
+        return nDigitFormat(value, 2);
+    }
+
+    private BigDecimal priceFormat(BigDecimal value) {
+        return nDigitFormat(value, 4);
+    }
+
+    private BigDecimal quantityFormat(BigDecimal value) {
+        return nDigitFormat(value, 4);
+    }
+
+    /**
+     * All files are PDF/A-3, setConformance refers to the level conformance.
+     *
+     * PDF/A-3 has three coformance levels, called "A", "U" and "B".
+     *
+     * PDF/A-3-B where B means only visually preservable, U -standard for
+     * Mustang- means visually and unicode preservable and A means full
+     * compliance, i.e. visually, unicode and structurally preservable and
+     * tagged PDF, i.e. useful metainformation for blind people.
+     *
+     * Feel free to pass "A" as new level if you know what you are doing :-)
+     *
+     *
+     */
+    public void setConformanceLevel(String newLevel) {
+        conformanceLevel = newLevel;
+    }
+
+    /**
+     * enables the flag to indicate a test invoice in the XML structure
+     *
+     */
+    public void setTest() {
+        isTest = true;
+    }
+
+    /**
+     * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on
+     * the metadata level, this will not e.g. convert graphics to JPG-2000)
+     *
+     */
+    public PDDocumentCatalog PDFmakeA3compliant(PDDocument doc, String producer, String creator,
+            boolean attachZugferdHeaders) throws IOException,
+            TransformerException {
+        String fullProducer = producer + " (via mustangproject.org " + versionStr + ")";
+        PDDocumentCatalog cat = doc.getDocumentCatalog();
+        PDMetadata metadata = new PDMetadata(doc);
+        cat.setMetadata(metadata);
+        // we're using the jempbox org.apache.jempbox.xmp.XMPMetadata version,
+        // not the xmpbox one
+        XMPMetadata xmp = new XMPMetadata();
+
+        XMPSchemaPDFAId pdfaid = new XMPSchemaPDFAId(xmp);
+        pdfaid.setAbout(""); //$NON-NLS-1$
+        xmp.addSchema(pdfaid);
+
+        XMPSchemaDublinCore dc = xmp.addDublinCoreSchema();
+        dc.addCreator(creator);
+        dc.setAbout(""); //$NON-NLS-1$
+
+        XMPSchemaBasic xsb = xmp.addBasicSchema();
+        xsb.setAbout(""); //$NON-NLS-1$
+
+        xsb.setCreatorTool(creator);
+        xsb.setCreateDate(GregorianCalendar.getInstance());
+        // PDDocumentInformation pdi=doc.getDocumentInformation();
+        PDDocumentInformation pdi = new PDDocumentInformation();
+        pdi.setProducer(fullProducer);
+        pdi.setAuthor(creator);
+        doc.setDocumentInformation(pdi);
+
+        XMPSchemaPDF pdf = xmp.addPDFSchema();
+        pdf.setProducer(fullProducer);
+        pdf.setAbout(""); //$NON-NLS-1$
+
+        /*
+         // Mandatory: PDF/A3-a is tagged PDF which has to be expressed using a
+         // MarkInfo dictionary (PDF A/3 Standard sec. 6.7.2.2)
+         PDMarkInfo markinfo = new PDMarkInfo();
+         markinfo.setMarked(true);
+         doc.getDocumentCatalog().setMarkInfo(markinfo);
+         */
+        /*
+         *
+         To be on the safe side, we use level B without Markinfo because we can not
+         guarantee that the user  correctly tagged the templates for the PDF.
+
+         * */
+        pdfaid.setConformance(conformanceLevel);//$NON-NLS-1$ //$NON-NLS-1$
+
+        pdfaid.setPart(3);
+
+        if (attachZugferdHeaders) {
+            addZugferdXMP(xmp); /*
+             * this is the only line where we do something
+             * Zugferd-specific, i.e. add PDF metadata
+             * specifically for Zugferd, not generically for
+             * a embedded file
+             */
+
+        }
+
+        metadata.importXMPMetadata(xmp);
+        return cat;
+    }
+
+    private static final ObjectFactory xmlFactory = new ObjectFactory();
+    private final JAXBContext jaxbContext;
+    private final Marshaller marshaller;
+    private static final SimpleDateFormat germanDateFormat = new SimpleDateFormat("dd.MM.yyyy"); //$NON-NLS-1$
+    private static final SimpleDateFormat zugferdDateFormat = new SimpleDateFormat("yyyyMMdd"); //$NON-NLS-1$
+
+    private String getZugferdXMLForTransaction(IZUGFeRDExportableTransaction trans) throws JAXBException {
+        this.trans = trans;
+
+        CrossIndustryDocumentType invoice = xmlFactory.createCrossIndustryDocumentType();
+
+        invoice.setSpecifiedExchangedDocumentContext(this.getDocumentContext());
+        invoice.setHeaderExchangedDocument(this.getDocument());
+        invoice.setSpecifiedSupplyChainTradeTransaction(this.getTradeTransaction());
+
+        JAXBElement<CrossIndustryDocumentType> jaxElement = xmlFactory.createCrossIndustryDocument(invoice);
+
+        ByteArrayOutputStream outputXml = new ByteArrayOutputStream();
+        marshaller.marshal(jaxElement, outputXml);
+
+        return outputXml.toString();
+    }
+
+    private ExchangedDocumentContextType getDocumentContext() {
+
+        ExchangedDocumentContextType context = xmlFactory.createExchangedDocumentContextType();
+        DocumentContextParameterType contextParameter = xmlFactory.createDocumentContextParameterType();
+        IDType idType = xmlFactory.createIDType();
+        idType.setValue(DocumentContextParameterType.COMFORT);
+        contextParameter.setID(idType);
+        context.getGuidelineSpecifiedDocumentContextParameter().add(contextParameter);
+        
+        IndicatorType testIndicator = xmlFactory.createIndicatorType();
+        testIndicator.setIndicator(isTest);
+        context.setTestIndicator(testIndicator);
+
+        return context;
+    }
+
+    private ExchangedDocumentType getDocument() {
+
+        ExchangedDocumentType document = xmlFactory.createExchangedDocumentType();
+
+        IDType id = xmlFactory.createIDType();
+        id.setValue(trans.getNumber());
+        document.setID(id);
+
+        DateTimeType issueDateTime = xmlFactory.createDateTimeType();
+        DateTimeType.DateTimeString issueDateTimeString = xmlFactory.createDateTimeTypeDateTimeString();
+        issueDateTimeString.setFormat(DateTimeType.DateTimeString.DATE);
+        issueDateTimeString.setValue(zugferdDateFormat.format(trans.getIssueDate()));
+        issueDateTime.setDateTimeString(issueDateTimeString);
+        document.setIssueDateTime(issueDateTime);
+
+        DocumentCodeType documentCodeType = xmlFactory.createDocumentCodeType();
+        documentCodeType.setValue(DocumentCodeType.INVOICE);
+        document.setTypeCode(documentCodeType);
+
+        if (trans.getOwnOrganisationFullPlaintextInfo() != null) {
+            NoteType regularInfo = xmlFactory.createNoteType();
+            CodeType regularInfoSubjectCode = xmlFactory.createCodeType();
+            regularInfoSubjectCode.setValue(NoteType.REGULARINFO);
+            regularInfo.setSubjectCode(regularInfoSubjectCode);
+            TextType regularInfoContent = xmlFactory.createTextType();
+            regularInfoContent.setValue(trans.getOwnOrganisationFullPlaintextInfo());
+            regularInfo.getContent().add(regularInfoContent);
+            document.getIncludedNote().add(regularInfo);
+        }
+
+        return document;
+    }
+
+    private SupplyChainTradeTransactionType getTradeTransaction() {
+
+        SupplyChainTradeTransactionType transaction = xmlFactory.createSupplyChainTradeTransactionType();
+        transaction.getApplicableSupplyChainTradeAgreement().add(this.getTradeAgreement());
+        transaction.setApplicableSupplyChainTradeDelivery(this.getTradeDelivery());
+        transaction.setApplicableSupplyChainTradeSettlement(this.getTradeSettlement());
+        transaction.getIncludedSupplyChainTradeLineItem().addAll(this.getLineItems());
+
+        return transaction;
+    }
+
+    private SupplyChainTradeAgreementType getTradeAgreement() {
+
+        SupplyChainTradeAgreementType tradeAgreement = xmlFactory.createSupplyChainTradeAgreementType();
+
+        tradeAgreement.setBuyerTradeParty(this.getBuyer());
+        tradeAgreement.setSellerTradeParty(this.getSeller());
+
+        return tradeAgreement;
+    }
+
+    private TradePartyType getBuyer() {
+
+        TradePartyType buyerTradeParty = xmlFactory.createTradePartyType();
+        TextType buyerName = xmlFactory.createTextType();
+        buyerName.setValue(trans.getRecipient().getName());
+        buyerTradeParty.setName(buyerName);
+
+        TradeAddressType buyerAddressType = xmlFactory.createTradeAddressType();
+        TextType buyerCityName = xmlFactory.createTextType();
+        buyerCityName.setValue(trans.getRecipient().getLocation());
+        buyerAddressType.setCityName(buyerCityName);
+
+        CountryIDType buyerCountryId = xmlFactory.createCountryIDType();
+        buyerCountryId.setValue(trans.getRecipient().getCountry());
+        buyerAddressType.setCountryID(buyerCountryId);
+
+        TextType buyerAddress = xmlFactory.createTextType();
+        buyerAddress.setValue(trans.getRecipient().getStreet());
+        buyerAddressType.setLineOne(buyerAddress);
+
+        CodeType buyerPostcode = xmlFactory.createCodeType();
+        buyerPostcode.setValue(trans.getRecipient().getZIP());
+        buyerAddressType.getPostcodeCode().add(buyerPostcode);
+
+        buyerTradeParty.setPostalTradeAddress(buyerAddressType);
+
+        // Ust-ID
+        TaxRegistrationType buyerTaxRegistration = xmlFactory.createTaxRegistrationType();
+        IDType buyerUstId = xmlFactory.createIDType();
+        buyerUstId.setValue(trans.getRecipient().getVATID());
+        buyerUstId.setSchemeID(TaxRegistrationType.USTID);
+        buyerTaxRegistration.setID(buyerUstId);
+        buyerTradeParty.getSpecifiedTaxRegistration().add(buyerTaxRegistration);
+
+        return buyerTradeParty;
+    }
+
+    private TradePartyType getSeller() {
+
+        TradePartyType sellerTradeParty = xmlFactory.createTradePartyType();
+        TextType sellerName = xmlFactory.createTextType();
+        sellerName.setValue(trans.getOwnOrganisationName());
+        sellerTradeParty.setName(sellerName);
+
+        TradeAddressType sellerAddressType = xmlFactory.createTradeAddressType();
+        TextType sellerCityName = xmlFactory.createTextType();
+        sellerCityName.setValue(trans.getOwnLocation());
+        sellerAddressType.setCityName(sellerCityName);
+
+        CountryIDType sellerCountryId = xmlFactory.createCountryIDType();
+        sellerCountryId.setValue(trans.getOwnCountry());
+        sellerAddressType.setCountryID(sellerCountryId);
+
+        TextType sellerAddress = xmlFactory.createTextType();
+        sellerAddress.setValue(trans.getOwnStreet());
+        sellerAddressType.setLineOne(sellerAddress);
+
+        CodeType sellerPostcode = xmlFactory.createCodeType();
+        sellerPostcode.setValue(trans.getOwnZIP());
+        sellerAddressType.getPostcodeCode().add(sellerPostcode);
+
+        sellerTradeParty.setPostalTradeAddress(sellerAddressType);
+
+        // Steuernummer
+        TaxRegistrationType sellerTaxRegistration = xmlFactory.createTaxRegistrationType();
+        IDType sellerTaxId = xmlFactory.createIDType();
+        sellerTaxId.setValue(trans.getOwnTaxID());
+        sellerTaxId.setSchemeID(TaxRegistrationType.TAXID);
+        sellerTaxRegistration.setID(sellerTaxId);
+        sellerTradeParty.getSpecifiedTaxRegistration().add(sellerTaxRegistration);
+
+        // Ust-ID
+        sellerTaxRegistration = xmlFactory.createTaxRegistrationType();
+        IDType sellerUstId = xmlFactory.createIDType();
+        sellerUstId.setValue(trans.getOwnVATID());
+        sellerUstId.setSchemeID(TaxRegistrationType.USTID);
+        sellerTaxRegistration.setID(sellerUstId);
+        sellerTradeParty.getSpecifiedTaxRegistration().add(sellerTaxRegistration);
+
+        return sellerTradeParty;
+    }
+
+    private SupplyChainTradeDeliveryType getTradeDelivery() {
+
+        SupplyChainTradeDeliveryType tradeDelivery = xmlFactory.createSupplyChainTradeDeliveryType();
+        SupplyChainEventType deliveryEvent = xmlFactory.createSupplyChainEventType();
+        DateTimeType deliveryDate = xmlFactory.createDateTimeType();
+        DateTimeType.DateTimeString deliveryDateString = xmlFactory.createDateTimeTypeDateTimeString();
+        deliveryDateString.setFormat(DateTimeType.DateTimeString.DATE);
+        deliveryDateString.setValue(zugferdDateFormat.format(trans.getDeliveryDate()));
+        deliveryDate.setDateTimeString(deliveryDateString);
+        deliveryEvent.getOccurrenceDateTime().add(deliveryDate);
+        tradeDelivery.getActualDeliverySupplyChainEvent().add(deliveryEvent);
+
+        return tradeDelivery;
+    }
+
+    private SupplyChainTradeSettlementType getTradeSettlement() {
+        SupplyChainTradeSettlementType tradeSettlement = xmlFactory.createSupplyChainTradeSettlementType();
+
+        TextType paymentReference = xmlFactory.createTextType();
+        paymentReference.setValue(trans.getNumber());
+        tradeSettlement.getPaymentReference().add(paymentReference);
+
+        CodeType currencyCode = xmlFactory.createCodeType();
+        currencyCode.setValue(trans.getInvoiceCurrency());
+        tradeSettlement.setInvoiceCurrencyCode(currencyCode);
+
+        tradeSettlement.getSpecifiedTradeSettlementPaymentMeans().add(this.getPaymentData());
+        tradeSettlement.getApplicableTradeTax().addAll(this.getTradeTax());
+        tradeSettlement.getSpecifiedTradePaymentTerms().addAll(this.getPaymentTerms());
+        tradeSettlement.setSpecifiedTradeSettlementMonetarySummation(this.getMonetarySummation());
+
+        return tradeSettlement;
+    }
+
+    private TradeSettlementPaymentMeansType getPaymentData() {
+        TradeSettlementPaymentMeansType paymentData = xmlFactory.createTradeSettlementPaymentMeansType();
+        PaymentMeansCodeType paymentDataType = xmlFactory.createPaymentMeansCodeType();
+        paymentDataType.setValue(PaymentMeansCodeType.BANKACCOUNT);
+        paymentData.setTypeCode(paymentDataType);
+
+        TextType paymentInfo = xmlFactory.createTextType();
+        paymentInfo.setValue(trans.getOwnPaymentInfoText());
+        paymentData.getInformation().add(paymentInfo);
+
+        CreditorFinancialAccountType bankAccount = xmlFactory.createCreditorFinancialAccountType();
+        IDType iban = xmlFactory.createIDType();
+        iban.setValue(trans.getOwnIBAN());
+        bankAccount.setIBANID(iban);
+        paymentData.setPayeePartyCreditorFinancialAccount(bankAccount);
+
+        CreditorFinancialInstitutionType bankData = xmlFactory.createCreditorFinancialInstitutionType();
+        IDType bicId = xmlFactory.createIDType();
+        bicId.setValue(trans.getOwnBIC());
+        bankData.setBICID(bicId);
+        TextType bankName = xmlFactory.createTextType();
+        bankName.setValue(trans.getOwnBankName());
+        bankData.setName(bankName);
+        paymentData.setPayeeSpecifiedCreditorFinancialInstitution(bankData);
+        return paymentData;
+    }
+
+    private Collection<TradeTaxType> getTradeTax() {
+        List<TradeTaxType> tradeTaxTypes = new ArrayList<TradeTaxType>();
+
+        HashMap<BigDecimal, VATAmount> VATPercentAmountMap = this.getVATPercentAmountMap();
+        for (BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
+
+            TradeTaxType tradeTax = xmlFactory.createTradeTaxType();
+            TaxTypeCodeType taxTypeCode = xmlFactory.createTaxTypeCodeType();
+            taxTypeCode.setValue(TaxTypeCodeType.SALESTAX);
+            tradeTax.setTypeCode(taxTypeCode);
+
+            TaxCategoryCodeType taxCategoryCode = xmlFactory.createTaxCategoryCodeType();
+            taxCategoryCode.setValue(TaxCategoryCodeType.STANDARDRATE);
+            tradeTax.setCategoryCode(taxCategoryCode);
+
+            VATAmount amount = VATPercentAmountMap.get(currentTaxPercent);
+
+            PercentType taxPercent = xmlFactory.createPercentType();
+            taxPercent.setValue(vatFormat(currentTaxPercent));
+            tradeTax.setApplicablePercent(taxPercent);
+
+            AmountType calculatedTaxAmount = xmlFactory.createAmountType();
+            calculatedTaxAmount.setCurrencyID(trans.getInvoiceCurrency());
+            calculatedTaxAmount.setValue(currencyFormat(amount.getCalculated()));
+            tradeTax.getCalculatedAmount().add(calculatedTaxAmount);
+
+            AmountType basisTaxAmount = xmlFactory.createAmountType();
+            basisTaxAmount.setCurrencyID(trans.getInvoiceCurrency());
+            basisTaxAmount.setValue(currencyFormat(amount.getBasis()));
+            tradeTax.getBasisAmount().add(basisTaxAmount);
+
+            tradeTaxTypes.add(tradeTax);
+        }
+
+        return tradeTaxTypes;
+    }
+
+    private Collection<TradePaymentTermsType> getPaymentTerms() {
+        List<TradePaymentTermsType> paymentTerms = new ArrayList<TradePaymentTermsType>();
+
+        TradePaymentTermsType paymentTerm = xmlFactory.createTradePaymentTermsType();
+        DateTimeType dueDate = xmlFactory.createDateTimeType();
+        DateTimeType.DateTimeString dueDateString = xmlFactory.createDateTimeTypeDateTimeString();
+        dueDateString.setFormat(DateTimeType.DateTimeString.DATE);
+        dueDateString.setValue(zugferdDateFormat.format(trans.getDueDate()));
+        dueDate.setDateTimeString(dueDateString);
+        paymentTerm.setDueDateDateTime(dueDate);
+
+        TextType paymentTermDescr = xmlFactory.createTextType();
+
+        paymentTermDescr.setValue(trans.getPaymentTermDescription());
+        paymentTerm.getDescription().add(paymentTermDescr);
+
+        paymentTerms.add(paymentTerm);
+
+        return paymentTerms;
+    }
+
+    private TradeSettlementMonetarySummationType getMonetarySummation() {
+        TradeSettlementMonetarySummationType monetarySummation = xmlFactory.createTradeSettlementMonetarySummationType();
+        AmountType allowanceTotalAmount = xmlFactory.createAmountType();
+        allowanceTotalAmount.setCurrencyID(trans.getInvoiceCurrency());
+        allowanceTotalAmount.setValue(currencyFormat(BigDecimal.ZERO));
+        monetarySummation.getAllowanceTotalAmount().add(allowanceTotalAmount);
+
+        AmountType chargeTotalAmount = xmlFactory.createAmountType();
+        chargeTotalAmount.setCurrencyID(trans.getInvoiceCurrency());
+        chargeTotalAmount.setValue(currencyFormat(BigDecimal.ZERO));
+        monetarySummation.getChargeTotalAmount().add(chargeTotalAmount);
+
+        AmountType lineTotalAmount = xmlFactory.createAmountType();
+        lineTotalAmount.setCurrencyID(trans.getInvoiceCurrency());
+        lineTotalAmount.setValue(currencyFormat(this.getTotal()));
+        monetarySummation.getLineTotalAmount().add(lineTotalAmount);
+
+        AmountType taxBasisTotalAmount = xmlFactory.createAmountType();
+        taxBasisTotalAmount.setCurrencyID(trans.getInvoiceCurrency());
+        taxBasisTotalAmount.setValue(currencyFormat(this.getTotal()));
+        monetarySummation.getTaxBasisTotalAmount().add(taxBasisTotalAmount);
+
+        AmountType taxTotalAmount = xmlFactory.createAmountType();
+        taxTotalAmount.setCurrencyID(trans.getInvoiceCurrency());
+        taxTotalAmount.setValue(currencyFormat(this.getTotalGross().subtract(this.getTotal())));
+        monetarySummation.getTaxTotalAmount().add(taxTotalAmount);
+
+        AmountType grandTotalAmount = xmlFactory.createAmountType();
+        grandTotalAmount.setCurrencyID(trans.getInvoiceCurrency());
+        grandTotalAmount.setValue(currencyFormat(this.getTotalGross()));
+        monetarySummation.getGrandTotalAmount().add(grandTotalAmount);
+
+        AmountType duePayableAmount = xmlFactory.createAmountType();
+        duePayableAmount.setCurrencyID(trans.getInvoiceCurrency());
+        duePayableAmount.setValue(currencyFormat(this.getTotalGross()));
+        monetarySummation.getDuePayableAmount().add(duePayableAmount);
+
+        return monetarySummation;
+    }
+
+    private Collection<SupplyChainTradeLineItemType> getLineItems() {
+
+        ArrayList<SupplyChainTradeLineItemType> lineItems = new ArrayList<SupplyChainTradeLineItemType>();
+        int lineID = 0;
+        for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
+            lineID++;
+            LineCalc lc = new LineCalc(currentItem);
+            SupplyChainTradeLineItemType lineItem = xmlFactory.createSupplyChainTradeLineItemType();
+
+            DocumentLineDocumentType lineDocument = xmlFactory.createDocumentLineDocumentType();
+            IDType lineNumber = xmlFactory.createIDType();
+            lineNumber.setValue(Integer.toString(lineID));
+            lineDocument.setLineID(lineNumber);
+            lineItem.setAssociatedDocumentLineDocument(lineDocument);
+
+            SupplyChainTradeAgreementType tradeAgreement = xmlFactory.createSupplyChainTradeAgreementType();
+            TradePriceType grossTradePrice = xmlFactory.createTradePriceType();
+            QuantityType grossQuantity = xmlFactory.createQuantityType();
+            grossQuantity.setUnitCode(currentItem.getProduct().getUnit());
+            grossQuantity.setValue(quantityFormat(BigDecimal.ONE));
+            grossTradePrice.setBasisQuantity(grossQuantity);
+
+            AmountType grossChargeAmount = xmlFactory.createAmountType();
+            grossChargeAmount.setCurrencyID(trans.getInvoiceCurrency());
+            grossChargeAmount.setValue(currencyFormat(currentItem.getPrice()));
+            grossTradePrice.getChargeAmount().add(grossChargeAmount);
+            tradeAgreement.getGrossPriceProductTradePrice().add(grossTradePrice);
+
+            TradePriceType netTradePrice = xmlFactory.createTradePriceType();
+            QuantityType netQuantity = xmlFactory.createQuantityType();
+            netQuantity.setUnitCode(currentItem.getProduct().getUnit());
+            netQuantity.setValue(quantityFormat(BigDecimal.ONE));
+            netTradePrice.setBasisQuantity(netQuantity);
+
+            AmountType netChargeAmount = xmlFactory.createAmountType();
+            netChargeAmount.setCurrencyID(trans.getInvoiceCurrency());
+            netChargeAmount.setValue(currencyFormat(currentItem.getPrice()));
+            netTradePrice.getChargeAmount().add(netChargeAmount);
+            tradeAgreement.getNetPriceProductTradePrice().add(netTradePrice);
+
+            lineItem.setSpecifiedSupplyChainTradeAgreement(tradeAgreement);
+
+            SupplyChainTradeDeliveryType tradeDelivery = xmlFactory.createSupplyChainTradeDeliveryType();
+            QuantityType billedQuantity = xmlFactory.createQuantityType();
+            billedQuantity.setUnitCode(currentItem.getProduct().getUnit());
+            billedQuantity.setValue(quantityFormat(currentItem.getQuantity()));
+            tradeDelivery.setBilledQuantity(billedQuantity);
+            lineItem.setSpecifiedSupplyChainTradeDelivery(tradeDelivery);
+
+            SupplyChainTradeSettlementType tradeSettlement = xmlFactory.createSupplyChainTradeSettlementType();
+            TradeTaxType tradeTax = xmlFactory.createTradeTaxType();
+            PercentType taxPercent = xmlFactory.createPercentType();
+            taxPercent.setValue(vatFormat(currentItem.getProduct().getVATPercent()));
+            tradeTax.setApplicablePercent(taxPercent);
+            tradeSettlement.getApplicableTradeTax().add(tradeTax);
+
+            TradeSettlementMonetarySummationType monetarySummation = xmlFactory.createTradeSettlementMonetarySummationType();
+            AmountType itemAmount = xmlFactory.createAmountType();
+            itemAmount.setCurrencyID(trans.getInvoiceCurrency());
+            itemAmount.setValue(currencyFormat(lc.getItemTotalNetAmount()));
+            monetarySummation.getLineTotalAmount().add(itemAmount);
+            tradeSettlement.setSpecifiedTradeSettlementMonetarySummation(monetarySummation);
+
+            lineItem.setSpecifiedSupplyChainTradeSettlement(tradeSettlement);
+
+            TradeProductType tradeProduct = xmlFactory.createTradeProductType();
+            TextType productName = xmlFactory.createTextType();
+            productName.setValue(currentItem.getProduct().getName());
+            tradeProduct.getName().add(productName);
+
+            TextType productDescription = xmlFactory.createTextType();
+            productDescription.setValue(currentItem.getProduct().getDescription());
+            tradeProduct.getDescription().add(productDescription);
+            lineItem.setSpecifiedTradeProduct(tradeProduct);
+
+            lineItems.add(lineItem);
+        }
+
+        return lineItems;
+
+    }
+
+    private BigDecimal getTotalGross() {
+
+        BigDecimal res = getTotal();
+        HashMap<BigDecimal, VATAmount> VATPercentAmountMap = getVATPercentAmountMap();
+        for (BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
+            VATAmount amount = VATPercentAmountMap.get(currentTaxPercent);
+            res = res.add(amount.getCalculated());
+        }
+
+        return res;
+    }
+
+    private BigDecimal getTotal() {
+        BigDecimal res = new BigDecimal(0);
+        for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
+            LineCalc lc = new LineCalc(currentItem);
+            res = res.add(lc.getItemTotalNetAmount());
+        }
+        return res;
+    }
+
+    /**
+     * which taxes have been used with which amounts in this transaction, empty
+     * for no taxes, or e.g. 19=>190 and 7=>14 if 1000 Eur were applicable to
+     * 19% VAT (=>190 EUR VAT) and 200 EUR were applicable to 7% (=>14 EUR VAT)
+     * 190 Eur
+     *
+     * @return
+     *
+     */
+    private HashMap<BigDecimal, VATAmount> getVATPercentAmountMap() {
+        HashMap<BigDecimal, VATAmount> hm = new HashMap<BigDecimal, VATAmount>();
+
+        for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
+            BigDecimal percent = currentItem.getProduct().getVATPercent();
+            LineCalc lc = new LineCalc(currentItem);
+            VATAmount itemVATAmount = new VATAmount(lc.getItemTotalNetAmount(), lc.getItemTotalVATAmount());
+            VATAmount current = hm.get(percent);
+            if (current == null) {
+                hm.put(percent, itemVATAmount);
+            } else {
+                hm.put(percent, current.add(itemVATAmount));
+
+            }
+        }
+
+        return hm;
+    }
+
+    /**
+     * Embeds the Zugferd XML structure in a file named ZUGFeRD-invoice.xml.
+     *
+     * @param doc PDDocument to attach an XML invoice to
+     * @param trans a IZUGFeRDExportableTransaction that provides the data-model
+     * to populate the XML. This parameter may be null, if so the XML data
+     * should hav ebeen set via
+     * <code>setZUGFeRDXMLData(byte[] zugferdData)</code>
+     */
+    public void PDFattachZugferdFile(PDDocument doc, IZUGFeRDExportableTransaction trans) throws IOException, JAXBException {
+
+        if (zugferdData == null) // XML ZUGFeRD data not set externally, needs to be built
+        {
+            // create a dummy file stream, this would probably normally be a
+            // FileInputStream
+
+            byte[] zugferdRaw = getZugferdXMLForTransaction(trans).getBytes("UTF-8"); //$NON-NLS-1$
+
+            if ((zugferdRaw[0] == (byte) 0xEF) && (zugferdRaw[1] == (byte) 0xBB) && (zugferdRaw[2] == (byte) 0xBF)) {
+                // I don't like BOMs, lets remove it
+                zugferdData = new byte[zugferdRaw.length - 3];
+                System.arraycopy(zugferdRaw, 3, zugferdData, 0, zugferdRaw.length - 3);
+            } else {
+                zugferdData = zugferdRaw;
+            }
+        }
+
+        PDFAttachGenericFile(doc, "ZUGFeRD-invoice.xml", "Alternative", "Invoice metadata conforming to ZUGFeRD standard (http://www.ferd-net.de/front_content.php?idcat=231&lang=4)", "text/xml", zugferdData);
+    }
+
+    /**
+     * Embeds an external file (generic - any type allowed) in the PDF.
+     *
+     * @param doc PDDocument to attach the file to.
+     * @param filename name of the file that will become attachment name in the
+     * PDF
+     * @param relationship how the file relates to the content, e.g.
+     * "Alternative"
+     * @param description Human-readable description of the file content
+     * @param subType type of the data e.g. could be "text/xml" - mime like
+     * @param data the binary data of the file/attachment
+     */
+    public void PDFAttachGenericFile(PDDocument doc, String filename, String relationship, String description, String subType, byte[] data)
+            throws IOException {
+        PDComplexFileSpecification fs = new PDComplexFileSpecification();
+        fs.setFile(filename);
+
+        COSDictionary dict = fs.getCOSDictionary();
+        dict.setName("AFRelationship", relationship);
+        dict.setString("UF", filename);
+        dict.setString("Desc", description);
+
+        ByteArrayInputStream fakeFile = new ByteArrayInputStream(data);
+        PDEmbeddedFile ef = new PDEmbeddedFile(doc, fakeFile);
+        ef.setSubtype(subType);
+        ef.setSize(data.length);
+        ef.setCreationDate(new GregorianCalendar());
+
+        ef.setModDate(GregorianCalendar.getInstance());
+
+        fs.setEmbeddedFile(ef);
+
+        // In addition make sure the embedded file is set under /UF
+        dict = fs.getCOSDictionary();
+        COSDictionary efDict = (COSDictionary) dict.getDictionaryObject(COSName.EF);
+        COSBase lowerLevelFile = efDict.getItem(COSName.F);
+        efDict.setItem(COSName.UF, lowerLevelFile);
+
+        // now add the entry to the embedded file tree and set in the document.
+        PDDocumentNameDictionary names = new PDDocumentNameDictionary(doc.getDocumentCatalog());
+        PDEmbeddedFilesNameTreeNode efTree = names.getEmbeddedFiles();
+        if (efTree == null) {
+            efTree = new PDEmbeddedFilesNameTreeNode();
+        }
+
+        Map<String, COSObjectable> namesMap = new HashMap<String, COSObjectable>();
+        Map<String, COSObjectable> oldNamesMap = efTree.getNames();
+        if (oldNamesMap != null) {
+            for (String key : oldNamesMap.keySet()) {
+                namesMap.put(key, oldNamesMap.get(key));
+            }
+        }
+        namesMap.put(filename, fs);
+        efTree.setNames(namesMap);
+
+        names.setEmbeddedFiles(efTree);
+        doc.getDocumentCatalog().setNames(names);
+
+        // AF entry (Array) in catalog with the FileSpec
+        COSArray cosArray = (COSArray) doc.getDocumentCatalog().getCOSDictionary().getItem("AF");
+        if (cosArray == null) {
+            cosArray = new COSArray();
+        }
+        cosArray.add(fs);
+        doc.getDocumentCatalog().getCOSDictionary().setItem("AF", cosArray);
+    }
+
+    /**
+     * Sets the ZUGFeRD XML data to be attached as a single byte array. This is
+     * useful for use-cases where the XML has already been produced by some
+     * external API or component.
+     *
+     * @param zugferdData XML data to be set as a byte array (XML file in raw
+     * form).
+     */
+    public void setZUGFeRDXMLData(byte[] zugferdData) {
+        this.zugferdData = zugferdData;
+    }
+
+    /**
+     * Sets the ZUGFeRD conformance level (override).
+     *
+     * @param ZUGFeRDConformanceLevel the new conformance level
+     */
+    public void setZUGFeRDConformanceLevel(String ZUGFeRDConformanceLevel) {
+        this.ZUGFeRDConformanceLevel = ZUGFeRDConformanceLevel;
+    }
+
+    /**
+     * *
+     * This will add both the RDF-indication which embedded file is Zugferd and
+     * the neccessary PDF/A schema extension description to be able to add this
+     * information to RDF
+     *
+     * @param metadata
+     */
+    private void addZugferdXMP(XMPMetadata metadata) {
+
+        XMPSchemaZugferd zf = new XMPSchemaZugferd(metadata, this.ZUGFeRDConformanceLevel);
+        zf.setAbout(""); //$NON-NLS-1$
+        metadata.addSchema(zf);
+
+        XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(metadata);
+        pdfaex.setAbout(""); //$NON-NLS-1$
+        metadata.addSchema(pdfaex);
+
+    }
 
 }

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -11,7 +11,6 @@ package org.mustangproject.ZUGFeRD;
  */
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
@@ -24,8 +23,6 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/AllowanceChargeReasonCodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/AllowanceChargeReasonCodeType.java
@@ -1,0 +1,69 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r AllowanceChargeReasonCodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="AllowanceChargeReasonCodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;AllowanceChargeReasonCodeContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AllowanceChargeReasonCodeType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class AllowanceChargeReasonCodeType {
+
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/AmountType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/AmountType.java
@@ -1,0 +1,98 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.math.BigDecimal;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r AmountType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="AmountType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;decimal"&gt;
+ *       &lt;attribute name="currencyID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountTypeCurrencyIDContentType" /&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AmountType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class AmountType {
+
+    @XmlValue
+    protected BigDecimal value;
+    @XmlAttribute(name = "currencyID")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String currencyID;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    /**
+     * Ruft den Wert der currencyID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getCurrencyID() {
+        return currencyID;
+    }
+
+    /**
+     * Legt den Wert der currencyID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setCurrencyID(String value) {
+        this.currencyID = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CodeType.java
@@ -1,0 +1,130 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r CodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="CodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;token"&gt;
+ *       &lt;attribute name="listID" type="{http://www.w3.org/2001/XMLSchema}token" /&gt;
+ *       &lt;attribute name="listVersionID" type="{http://www.w3.org/2001/XMLSchema}token" /&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "CodeType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class CodeType {
+    
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    @XmlSchemaType(name = "token")
+    protected String value;
+    @XmlAttribute(name = "listID")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    @XmlSchemaType(name = "token")
+    protected String listID;
+    @XmlAttribute(name = "listVersionID")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    @XmlSchemaType(name = "token")
+    protected String listVersionID;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Ruft den Wert der listID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getListID() {
+        return listID;
+    }
+
+    /**
+     * Legt den Wert der listID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setListID(String value) {
+        this.listID = value;
+    }
+
+    /**
+     * Ruft den Wert der listVersionID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getListVersionID() {
+        return listVersionID;
+    }
+
+    /**
+     * Legt den Wert der listVersionID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setListVersionID(String value) {
+        this.listVersionID = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CountryIDType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CountryIDType.java
@@ -1,0 +1,69 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r CountryIDType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="CountryIDType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;CountryIDContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "CountryIDType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class CountryIDType {
+
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CreditorFinancialAccountType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CreditorFinancialAccountType.java
@@ -1,0 +1,125 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r CreditorFinancialAccountType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="CreditorFinancialAccountType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="IBANID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="AccountName" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="ProprietaryID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "CreditorFinancialAccountType", propOrder = {
+    "ibanid",
+    "accountName",
+    "proprietaryID"
+})
+public class CreditorFinancialAccountType {
+
+    @XmlElement(name = "IBANID")
+    protected IDType ibanid;
+    @XmlElement(name = "AccountName")
+    protected TextType accountName;
+    @XmlElement(name = "ProprietaryID")
+    protected IDType proprietaryID;
+
+    /**
+     * Ruft den Wert der ibanid-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getIBANID() {
+        return ibanid;
+    }
+
+    /**
+     * Legt den Wert der ibanid-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setIBANID(IDType value) {
+        this.ibanid = value;
+    }
+
+    /**
+     * Ruft den Wert der accountName-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getAccountName() {
+        return accountName;
+    }
+
+    /**
+     * Legt den Wert der accountName-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setAccountName(TextType value) {
+        this.accountName = value;
+    }
+
+    /**
+     * Ruft den Wert der proprietaryID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getProprietaryID() {
+        return proprietaryID;
+    }
+
+    /**
+     * Legt den Wert der proprietaryID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setProprietaryID(IDType value) {
+        this.proprietaryID = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CreditorFinancialInstitutionType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CreditorFinancialInstitutionType.java
@@ -1,0 +1,125 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r CreditorFinancialInstitutionType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="CreditorFinancialInstitutionType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="BICID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="GermanBankleitzahlID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="Name" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "CreditorFinancialInstitutionType", propOrder = {
+    "bicid",
+    "germanBankleitzahlID",
+    "name"
+})
+public class CreditorFinancialInstitutionType {
+
+    @XmlElement(name = "BICID")
+    protected IDType bicid;
+    @XmlElement(name = "GermanBankleitzahlID")
+    protected IDType germanBankleitzahlID;
+    @XmlElement(name = "Name")
+    protected TextType name;
+
+    /**
+     * Ruft den Wert der bicid-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getBICID() {
+        return bicid;
+    }
+
+    /**
+     * Legt den Wert der bicid-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setBICID(IDType value) {
+        this.bicid = value;
+    }
+
+    /**
+     * Ruft den Wert der germanBankleitzahlID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getGermanBankleitzahlID() {
+        return germanBankleitzahlID;
+    }
+
+    /**
+     * Legt den Wert der germanBankleitzahlID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setGermanBankleitzahlID(IDType value) {
+        this.germanBankleitzahlID = value;
+    }
+
+    /**
+     * Ruft den Wert der name-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getName() {
+        return name;
+    }
+
+    /**
+     * Legt den Wert der name-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setName(TextType value) {
+        this.name = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CrossIndustryDocumentType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/CrossIndustryDocumentType.java
@@ -1,0 +1,128 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r CrossIndustryDocumentType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="CrossIndustryDocumentType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="SpecifiedExchangedDocumentContext" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ExchangedDocumentContextType"/&gt;
+ *         &lt;element name="HeaderExchangedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ExchangedDocumentType"/&gt;
+ *         &lt;element name="SpecifiedSupplyChainTradeTransaction" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeTransactionType"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name="CrossIndustryDocumentType", namespace="urn:ferd:CrossIndustryDocument:invoice:1p0")
+@XmlType(name = "CrossIndustryDocumentType", namespace = "urn:ferd:CrossIndustryDocument:invoice:1p0", propOrder = {
+    "specifiedExchangedDocumentContext",
+    "headerExchangedDocument",
+    "specifiedSupplyChainTradeTransaction"
+})
+public class CrossIndustryDocumentType {
+
+    @XmlElement(name = "SpecifiedExchangedDocumentContext", required = true)
+    protected ExchangedDocumentContextType specifiedExchangedDocumentContext;
+    @XmlElement(name = "HeaderExchangedDocument", required = true)
+    protected ExchangedDocumentType headerExchangedDocument;
+    @XmlElement(name = "SpecifiedSupplyChainTradeTransaction", required = true)
+    protected SupplyChainTradeTransactionType specifiedSupplyChainTradeTransaction;
+
+    /**
+     * Ruft den Wert der specifiedExchangedDocumentContext-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ExchangedDocumentContextType }
+     *     
+     */
+    public ExchangedDocumentContextType getSpecifiedExchangedDocumentContext() {
+        return specifiedExchangedDocumentContext;
+    }
+
+    /**
+     * Legt den Wert der specifiedExchangedDocumentContext-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ExchangedDocumentContextType }
+     *     
+     */
+    public void setSpecifiedExchangedDocumentContext(ExchangedDocumentContextType value) {
+        this.specifiedExchangedDocumentContext = value;
+    }
+
+    /**
+     * Ruft den Wert der headerExchangedDocument-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ExchangedDocumentType }
+     *     
+     */
+    public ExchangedDocumentType getHeaderExchangedDocument() {
+        return headerExchangedDocument;
+    }
+
+    /**
+     * Legt den Wert der headerExchangedDocument-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ExchangedDocumentType }
+     *     
+     */
+    public void setHeaderExchangedDocument(ExchangedDocumentType value) {
+        this.headerExchangedDocument = value;
+    }
+
+    /**
+     * Ruft den Wert der specifiedSupplyChainTradeTransaction-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SupplyChainTradeTransactionType }
+     *     
+     */
+    public SupplyChainTradeTransactionType getSpecifiedSupplyChainTradeTransaction() {
+        return specifiedSupplyChainTradeTransaction;
+    }
+
+    /**
+     * Legt den Wert der specifiedSupplyChainTradeTransaction-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SupplyChainTradeTransactionType }
+     *     
+     */
+    public void setSpecifiedSupplyChainTradeTransaction(SupplyChainTradeTransactionType value) {
+        this.specifiedSupplyChainTradeTransaction = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DateTimeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DateTimeType.java
@@ -1,0 +1,162 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+
+/**
+ * <p>Java-Klasse f�r DateTimeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="DateTimeType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice&gt;
+ *         &lt;element name="DateTimeString"&gt;
+ *           &lt;complexType&gt;
+ *             &lt;simpleContent&gt;
+ *               &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;string"&gt;
+ *                 &lt;attribute name="format" type="{http://www.w3.org/2001/XMLSchema}string" /&gt;
+ *               &lt;/extension&gt;
+ *             &lt;/simpleContent&gt;
+ *           &lt;/complexType&gt;
+ *         &lt;/element&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DateTimeType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "dateTimeString"
+})
+public class DateTimeType {
+
+    @XmlElement(name = "DateTimeString")
+    protected DateTimeType.DateTimeString dateTimeString;
+
+    /**
+     * Ruft den Wert der dateTimeString-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType.DateTimeString }
+     *     
+     */
+    public DateTimeType.DateTimeString getDateTimeString() {
+        return dateTimeString;
+    }
+
+    /**
+     * Legt den Wert der dateTimeString-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType.DateTimeString }
+     *     
+     */
+    public void setDateTimeString(DateTimeType.DateTimeString value) {
+        this.dateTimeString = value;
+    }
+
+
+    /**
+     * <p>Java-Klasse f�r anonymous complex type.
+     * 
+     * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+     * 
+     * <pre>
+     * &lt;complexType&gt;
+     *   &lt;simpleContent&gt;
+     *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;string"&gt;
+     *       &lt;attribute name="format" type="{http://www.w3.org/2001/XMLSchema}string" /&gt;
+     *     &lt;/extension&gt;
+     *   &lt;/simpleContent&gt;
+     * &lt;/complexType&gt;
+     * </pre>
+     * 
+     * 
+     */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+        "value"
+    })
+    public static class DateTimeString {
+
+        public static final String DATE = "102";
+        public static final String MONTH = "610";        
+        public static final String WEEK = "616";
+        
+        @XmlValue
+        protected String value;
+        @XmlAttribute(name = "format")
+        protected String format;
+
+        /**
+         * Ruft den Wert der value-Eigenschaft ab.
+         * 
+         * @return
+         *     possible object is
+         *     {@link String }
+         *     
+         */
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Legt den Wert der value-Eigenschaft fest.
+         * 
+         * @param value
+         *     allowed object is
+         *     {@link String }
+         *     
+         */
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        /**
+         * Ruft den Wert der format-Eigenschaft ab.
+         * 
+         * @return
+         *     possible object is
+         *     {@link String }
+         *     
+         */
+        public String getFormat() {
+            return format;
+        }
+
+        /**
+         * Legt den Wert der format-Eigenschaft fest.
+         * 
+         * @param value
+         *     allowed object is
+         *     {@link String }
+         *     
+         */
+        public void setFormat(String value) {
+            this.format = value;
+        }
+
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DebtorFinancialAccountType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DebtorFinancialAccountType.java
@@ -1,0 +1,97 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r DebtorFinancialAccountType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="DebtorFinancialAccountType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="IBANID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="ProprietaryID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DebtorFinancialAccountType", propOrder = {
+    "ibanid",
+    "proprietaryID"
+})
+public class DebtorFinancialAccountType {
+
+    @XmlElement(name = "IBANID")
+    protected IDType ibanid;
+    @XmlElement(name = "ProprietaryID")
+    protected IDType proprietaryID;
+
+    /**
+     * Ruft den Wert der ibanid-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getIBANID() {
+        return ibanid;
+    }
+
+    /**
+     * Legt den Wert der ibanid-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setIBANID(IDType value) {
+        this.ibanid = value;
+    }
+
+    /**
+     * Ruft den Wert der proprietaryID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getProprietaryID() {
+        return proprietaryID;
+    }
+
+    /**
+     * Legt den Wert der proprietaryID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setProprietaryID(IDType value) {
+        this.proprietaryID = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DebtorFinancialInstitutionType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DebtorFinancialInstitutionType.java
@@ -1,0 +1,125 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r DebtorFinancialInstitutionType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="DebtorFinancialInstitutionType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="BICID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="GermanBankleitzahlID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="Name" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DebtorFinancialInstitutionType", propOrder = {
+    "bicid",
+    "germanBankleitzahlID",
+    "name"
+})
+public class DebtorFinancialInstitutionType {
+
+    @XmlElement(name = "BICID")
+    protected IDType bicid;
+    @XmlElement(name = "GermanBankleitzahlID")
+    protected IDType germanBankleitzahlID;
+    @XmlElement(name = "Name")
+    protected TextType name;
+
+    /**
+     * Ruft den Wert der bicid-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getBICID() {
+        return bicid;
+    }
+
+    /**
+     * Legt den Wert der bicid-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setBICID(IDType value) {
+        this.bicid = value;
+    }
+
+    /**
+     * Ruft den Wert der germanBankleitzahlID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getGermanBankleitzahlID() {
+        return germanBankleitzahlID;
+    }
+
+    /**
+     * Legt den Wert der germanBankleitzahlID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setGermanBankleitzahlID(IDType value) {
+        this.germanBankleitzahlID = value;
+    }
+
+    /**
+     * Ruft den Wert der name-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getName() {
+        return name;
+    }
+
+    /**
+     * Legt den Wert der name-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setName(TextType value) {
+        this.name = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DeliveryTermsCodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DeliveryTermsCodeType.java
@@ -1,0 +1,69 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r DeliveryTermsCodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="DeliveryTermsCodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;DeliveryTermsCodeContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DeliveryTermsCodeType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class DeliveryTermsCodeType {
+
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DocumentCodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DocumentCodeType.java
@@ -1,0 +1,73 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r DocumentCodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="DocumentCodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;DocumentCodeContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DocumentCodeType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class DocumentCodeType {
+
+    public static final String INVOICE = "380";
+    public static final String DEBITNOTE = "84";
+    public static final String CREDITNOTE = "389";
+    
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DocumentContextParameterType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DocumentContextParameterType.java
@@ -1,0 +1,72 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r DocumentContextParameterType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="DocumentContextParameterType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DocumentContextParameterType", propOrder = {
+    "id"
+})
+public class DocumentContextParameterType {
+    
+    public static final String COMFORT = "urn:ferd:CrossIndustryDocument:invoice:1p0:comfort";
+    public static final String EXTENDED = "urn:ferd:CrossIndustryDocument:invoice:1p0:extended";
+
+    @XmlElement(name = "ID")
+    protected IDType id;
+
+    /**
+     * Ruft den Wert der id-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getID() {
+        return id;
+    }
+
+    /**
+     * Legt den Wert der id-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setID(IDType value) {
+        this.id = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DocumentLineDocumentType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/DocumentLineDocumentType.java
@@ -1,0 +1,104 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r DocumentLineDocumentType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="DocumentLineDocumentType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="LineID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="IncludedNote" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}NoteType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DocumentLineDocumentType", propOrder = {
+    "lineID",
+    "includedNote"
+})
+public class DocumentLineDocumentType {
+
+    @XmlElement(name = "LineID")
+    protected IDType lineID;
+    @XmlElement(name = "IncludedNote")
+    protected List<NoteType> includedNote;
+
+    /**
+     * Ruft den Wert der lineID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getLineID() {
+        return lineID;
+    }
+
+    /**
+     * Legt den Wert der lineID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setLineID(IDType value) {
+        this.lineID = value;
+    }
+
+    /**
+     * Gets the value of the includedNote property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the includedNote property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getIncludedNote().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link NoteType }
+     * 
+     * 
+     */
+    public List<NoteType> getIncludedNote() {
+        if (includedNote == null) {
+            includedNote = new ArrayList<NoteType>();
+        }
+        return this.includedNote;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ExchangedDocumentContextType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ExchangedDocumentContextType.java
@@ -1,0 +1,137 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r ExchangedDocumentContextType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="ExchangedDocumentContextType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="TestIndicator" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IndicatorType" minOccurs="0"/&gt;
+ *         &lt;element name="BusinessProcessSpecifiedDocumentContextParameter" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}DocumentContextParameterType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="GuidelineSpecifiedDocumentContextParameter" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}DocumentContextParameterType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ExchangedDocumentContextType", propOrder = {
+    "testIndicator",
+    "businessProcessSpecifiedDocumentContextParameter",
+    "guidelineSpecifiedDocumentContextParameter"
+})
+public class ExchangedDocumentContextType {
+
+    @XmlElement(name = "TestIndicator")
+    protected IndicatorType testIndicator;
+    @XmlElement(name = "BusinessProcessSpecifiedDocumentContextParameter")
+    protected List<DocumentContextParameterType> businessProcessSpecifiedDocumentContextParameter;
+    @XmlElement(name = "GuidelineSpecifiedDocumentContextParameter")
+    protected List<DocumentContextParameterType> guidelineSpecifiedDocumentContextParameter;
+
+    /**
+     * Ruft den Wert der testIndicator-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IndicatorType }
+     *     
+     */
+    public IndicatorType getTestIndicator() {
+        return testIndicator;
+    }
+
+    /**
+     * Legt den Wert der testIndicator-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IndicatorType }
+     *     
+     */
+    public void setTestIndicator(IndicatorType value) {
+        this.testIndicator = value;
+    }
+
+    /**
+     * Gets the value of the businessProcessSpecifiedDocumentContextParameter property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the businessProcessSpecifiedDocumentContextParameter property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getBusinessProcessSpecifiedDocumentContextParameter().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link DocumentContextParameterType }
+     * 
+     * 
+     */
+    public List<DocumentContextParameterType> getBusinessProcessSpecifiedDocumentContextParameter() {
+        if (businessProcessSpecifiedDocumentContextParameter == null) {
+            businessProcessSpecifiedDocumentContextParameter = new ArrayList<DocumentContextParameterType>();
+        }
+        return this.businessProcessSpecifiedDocumentContextParameter;
+    }
+
+    /**
+     * Gets the value of the guidelineSpecifiedDocumentContextParameter property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the guidelineSpecifiedDocumentContextParameter property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getGuidelineSpecifiedDocumentContextParameter().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link DocumentContextParameterType }
+     * 
+     * 
+     */
+    public List<DocumentContextParameterType> getGuidelineSpecifiedDocumentContextParameter() {
+        if (guidelineSpecifiedDocumentContextParameter == null) {
+            guidelineSpecifiedDocumentContextParameter = new ArrayList<DocumentContextParameterType>();
+        }
+        return this.guidelineSpecifiedDocumentContextParameter;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ExchangedDocumentType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ExchangedDocumentType.java
@@ -1,0 +1,282 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r ExchangedDocumentType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="ExchangedDocumentType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="Name" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="TypeCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}DocumentCodeType" minOccurs="0"/&gt;
+ *         &lt;element name="IssueDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" minOccurs="0"/&gt;
+ *         &lt;element name="CopyIndicator" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IndicatorType" minOccurs="0"/&gt;
+ *         &lt;element name="LanguageID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="IncludedNote" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}NoteType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="EffectiveSpecifiedPeriod" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SpecifiedPeriodType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ExchangedDocumentType", propOrder = {
+    "id",
+    "name",
+    "typeCode",
+    "issueDateTime",
+    "copyIndicator",
+    "languageID",
+    "includedNote",
+    "effectiveSpecifiedPeriod"
+})
+public class ExchangedDocumentType {
+
+    @XmlElement(name = "ID")
+    protected IDType id;
+    @XmlElement(name = "Name")
+    protected List<TextType> name;
+    @XmlElement(name = "TypeCode")
+    protected DocumentCodeType typeCode;
+    @XmlElement(name = "IssueDateTime")
+    protected DateTimeType issueDateTime;
+    @XmlElement(name = "CopyIndicator")
+    protected IndicatorType copyIndicator;
+    @XmlElement(name = "LanguageID")
+    protected List<IDType> languageID;
+    @XmlElement(name = "IncludedNote")
+    protected List<NoteType> includedNote;
+    @XmlElement(name = "EffectiveSpecifiedPeriod")
+    protected SpecifiedPeriodType effectiveSpecifiedPeriod;
+
+    /**
+     * Ruft den Wert der id-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getID() {
+        return id;
+    }
+
+    /**
+     * Legt den Wert der id-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setID(IDType value) {
+        this.id = value;
+    }
+
+    /**
+     * Gets the value of the name property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the name property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getName().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getName() {
+        if (name == null) {
+            name = new ArrayList<TextType>();
+        }
+        return this.name;
+    }
+
+    /**
+     * Ruft den Wert der typeCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DocumentCodeType }
+     *     
+     */
+    public DocumentCodeType getTypeCode() {
+        return typeCode;
+    }
+
+    /**
+     * Legt den Wert der typeCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DocumentCodeType }
+     *     
+     */
+    public void setTypeCode(DocumentCodeType value) {
+        this.typeCode = value;
+    }
+
+    /**
+     * Ruft den Wert der issueDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public DateTimeType getIssueDateTime() {
+        return issueDateTime;
+    }
+
+    /**
+     * Legt den Wert der issueDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public void setIssueDateTime(DateTimeType value) {
+        this.issueDateTime = value;
+    }
+
+    /**
+     * Ruft den Wert der copyIndicator-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IndicatorType }
+     *     
+     */
+    public IndicatorType getCopyIndicator() {
+        return copyIndicator;
+    }
+
+    /**
+     * Legt den Wert der copyIndicator-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IndicatorType }
+     *     
+     */
+    public void setCopyIndicator(IndicatorType value) {
+        this.copyIndicator = value;
+    }
+
+    /**
+     * Gets the value of the languageID property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the languageID property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getLanguageID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link IDType }
+     * 
+     * 
+     */
+    public List<IDType> getLanguageID() {
+        if (languageID == null) {
+            languageID = new ArrayList<IDType>();
+        }
+        return this.languageID;
+    }
+
+    /**
+     * Gets the value of the includedNote property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the includedNote property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getIncludedNote().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link NoteType }
+     * 
+     * 
+     */
+    public List<NoteType> getIncludedNote() {
+        if (includedNote == null) {
+            includedNote = new ArrayList<NoteType>();
+        }
+        return this.includedNote;
+    }
+
+    /**
+     * Ruft den Wert der effectiveSpecifiedPeriod-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SpecifiedPeriodType }
+     *     
+     */
+    public SpecifiedPeriodType getEffectiveSpecifiedPeriod() {
+        return effectiveSpecifiedPeriod;
+    }
+
+    /**
+     * Legt den Wert der effectiveSpecifiedPeriod-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SpecifiedPeriodType }
+     *     
+     */
+    public void setEffectiveSpecifiedPeriod(SpecifiedPeriodType value) {
+        this.effectiveSpecifiedPeriod = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/IDType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/IDType.java
@@ -1,0 +1,129 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r IDType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="IDType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;token"&gt;
+ *       &lt;attribute name="schemeID" type="{http://www.w3.org/2001/XMLSchema}token" /&gt;
+ *       &lt;attribute name="schemeAgencyID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDTypeSchemeAgencyIDContentType" /&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IDType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class IDType {
+
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    @XmlSchemaType(name = "token")
+    protected String value;
+    @XmlAttribute(name = "schemeID")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    @XmlSchemaType(name = "token")
+    protected String schemeID;
+    @XmlAttribute(name = "schemeAgencyID")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String schemeAgencyID;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Ruft den Wert der schemeID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getSchemeID() {
+        return schemeID;
+    }
+
+    /**
+     * Legt den Wert der schemeID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setSchemeID(String value) {
+        this.schemeID = value;
+    }
+
+    /**
+     * Ruft den Wert der schemeAgencyID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getSchemeAgencyID() {
+        return schemeAgencyID;
+    }
+
+    /**
+     * Legt den Wert der schemeAgencyID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setSchemeAgencyID(String value) {
+        this.schemeAgencyID = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/IndicatorType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/IndicatorType.java
@@ -1,0 +1,69 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r IndicatorType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="IndicatorType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;choice&gt;
+ *         &lt;element name="Indicator" type="{http://www.w3.org/2001/XMLSchema}boolean"/&gt;
+ *       &lt;/choice&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndicatorType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "indicator"
+})
+public class IndicatorType {
+
+    @XmlElement(name = "Indicator")
+    protected Boolean indicator;
+
+    /**
+     * Ruft den Wert der indicator-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isIndicator() {
+        return indicator;
+    }
+
+    /**
+     * Legt den Wert der indicator-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setIndicator(Boolean value) {
+        this.indicator = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/LogisticsServiceChargeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/LogisticsServiceChargeType.java
@@ -1,0 +1,142 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r LogisticsServiceChargeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="LogisticsServiceChargeType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="Description" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="AppliedAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="AppliedTradeTax" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeTaxType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "LogisticsServiceChargeType", propOrder = {
+    "description",
+    "appliedAmount",
+    "appliedTradeTax"
+})
+public class LogisticsServiceChargeType {
+
+    @XmlElement(name = "Description")
+    protected List<TextType> description;
+    @XmlElement(name = "AppliedAmount")
+    protected List<AmountType> appliedAmount;
+    @XmlElement(name = "AppliedTradeTax")
+    protected List<TradeTaxType> appliedTradeTax;
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the description property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDescription().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getDescription() {
+        if (description == null) {
+            description = new ArrayList<TextType>();
+        }
+        return this.description;
+    }
+
+    /**
+     * Gets the value of the appliedAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the appliedAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getAppliedAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getAppliedAmount() {
+        if (appliedAmount == null) {
+            appliedAmount = new ArrayList<AmountType>();
+        }
+        return this.appliedAmount;
+    }
+
+    /**
+     * Gets the value of the appliedTradeTax property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the appliedTradeTax property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getAppliedTradeTax().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeTaxType }
+     * 
+     * 
+     */
+    public List<TradeTaxType> getAppliedTradeTax() {
+        if (appliedTradeTax == null) {
+            appliedTradeTax = new ArrayList<TradeTaxType>();
+        }
+        return this.appliedTradeTax;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/LogisticsTransportMovementType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/LogisticsTransportMovementType.java
@@ -1,0 +1,97 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r LogisticsTransportMovementType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="LogisticsTransportMovementType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ModeCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}CodeType" minOccurs="0"/&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "LogisticsTransportMovementType", propOrder = {
+    "modeCode",
+    "id"
+})
+public class LogisticsTransportMovementType {
+
+    @XmlElement(name = "ModeCode")
+    protected CodeType modeCode;
+    @XmlElement(name = "ID")
+    protected IDType id;
+
+    /**
+     * Ruft den Wert der modeCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CodeType }
+     *     
+     */
+    public CodeType getModeCode() {
+        return modeCode;
+    }
+
+    /**
+     * Legt den Wert der modeCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CodeType }
+     *     
+     */
+    public void setModeCode(CodeType value) {
+        this.modeCode = value;
+    }
+
+    /**
+     * Ruft den Wert der id-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getID() {
+        return id;
+    }
+
+    /**
+     * Legt den Wert der id-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setID(IDType value) {
+        this.id = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/MeasureType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/MeasureType.java
@@ -1,0 +1,98 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.math.BigDecimal;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r MeasureType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="MeasureType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;decimal"&gt;
+ *       &lt;attribute name="unitCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}MeasureTypeUnitCodeContentType" /&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "MeasureType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class MeasureType {
+
+    @XmlValue
+    protected BigDecimal value;
+    @XmlAttribute(name = "unitCode")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String unitCode;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    /**
+     * Ruft den Wert der unitCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getUnitCode() {
+        return unitCode;
+    }
+
+    /**
+     * Legt den Wert der unitCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setUnitCode(String value) {
+        this.unitCode = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/NoteType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/NoteType.java
@@ -1,0 +1,143 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r NoteType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="NoteType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ContentCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}CodeType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="Content" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SubjectCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}CodeType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "NoteType", propOrder = {
+    "contentCode",
+    "content",
+    "subjectCode"
+})
+public class NoteType {
+    
+    public static final String GENERAL = "";
+    public static final String REGULARINFO = "REG";
+    public static final String PRICECONDITION = "AAK";
+    public static final String CONDITIONS = "AAJ";
+    public static final String PAYMENTINFO = "PMT";
+    
+    @XmlElement(name = "ContentCode")
+    protected List<CodeType> contentCode;
+    @XmlElement(name = "Content")
+    protected List<TextType> content;
+    @XmlElement(name = "SubjectCode")
+    protected CodeType subjectCode;
+
+    /**
+     * Gets the value of the contentCode property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the contentCode property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getContentCode().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link CodeType }
+     * 
+     * 
+     */
+    public List<CodeType> getContentCode() {
+        if (contentCode == null) {
+            contentCode = new ArrayList<CodeType>();
+        }
+        return this.contentCode;
+    }
+
+    /**
+     * Gets the value of the content property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the content property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getContent().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getContent() {
+        if (content == null) {
+            content = new ArrayList<TextType>();
+        }
+        return this.content;
+    }
+
+    /**
+     * Ruft den Wert der subjectCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CodeType }
+     *     
+     */
+    public CodeType getSubjectCode() {
+        return subjectCode;
+    }
+
+    /**
+     * Legt den Wert der subjectCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CodeType }
+     *     
+     */
+    public void setSubjectCode(CodeType value) {
+        this.subjectCode = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/NumericType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/NumericType.java
@@ -1,0 +1,67 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.math.BigDecimal;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+
+/**
+ * <p>Java-Klasse f�r NumericType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="NumericType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;decimal"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "NumericType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class NumericType {
+
+    @XmlValue
+    protected BigDecimal value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ObjectFactory.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ObjectFactory.java
@@ -1,0 +1,533 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlRegistry;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.namespace.QName;
+
+
+/**
+ * This object contains factory methods for each 
+ * Java content interface and Java element interface 
+ * generated in the org.mustangproject.ZUGFeRD.model package. 
+ * <p>An ObjectFactory allows you to programatically 
+ * construct new instances of the Java representation 
+ * for XML content. The Java representation of XML 
+ * content can consist of schema derived interfaces 
+ * and classes representing the binding of schema 
+ * type definitions, element declarations and model 
+ * groups.  Factory methods for each of these are 
+ * provided in this class.
+ * 
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    private final static QName _CrossIndustryDocument_QNAME = new QName("urn:ferd:CrossIndustryDocument:invoice:1p0", "CrossIndustryDocument");
+
+    /**
+     * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: org.mustangproject.ZUGFeRD.model
+     * 
+     */
+    public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link DateTimeType }
+     * 
+     */
+    public DateTimeType createDateTimeType() {
+        return new DateTimeType();
+    }
+
+    /**
+     * Create an instance of {@link CrossIndustryDocumentType }
+     * 
+     */
+    public CrossIndustryDocumentType createCrossIndustryDocumentType() {
+        return new CrossIndustryDocumentType();
+    }
+
+    /**
+     * Create an instance of {@link AllowanceChargeReasonCodeType }
+     * 
+     */
+    public AllowanceChargeReasonCodeType createAllowanceChargeReasonCodeType() {
+        return new AllowanceChargeReasonCodeType();
+    }
+
+    /**
+     * Create an instance of {@link CountryIDType }
+     * 
+     */
+    public CountryIDType createCountryIDType() {
+        return new CountryIDType();
+    }
+
+    /**
+     * Create an instance of {@link DeliveryTermsCodeType }
+     * 
+     */
+    public DeliveryTermsCodeType createDeliveryTermsCodeType() {
+        return new DeliveryTermsCodeType();
+    }
+
+    /**
+     * Create an instance of {@link DocumentCodeType }
+     * 
+     */
+    public DocumentCodeType createDocumentCodeType() {
+        return new DocumentCodeType();
+    }
+
+    /**
+     * Create an instance of {@link PaymentMeansCodeType }
+     * 
+     */
+    public PaymentMeansCodeType createPaymentMeansCodeType() {
+        return new PaymentMeansCodeType();
+    }
+
+    /**
+     * Create an instance of {@link ReferenceCodeType }
+     * 
+     */
+    public ReferenceCodeType createReferenceCodeType() {
+        return new ReferenceCodeType();
+    }
+
+    /**
+     * Create an instance of {@link TaxCategoryCodeType }
+     * 
+     */
+    public TaxCategoryCodeType createTaxCategoryCodeType() {
+        return new TaxCategoryCodeType();
+    }
+
+    /**
+     * Create an instance of {@link TaxTypeCodeType }
+     * 
+     */
+    public TaxTypeCodeType createTaxTypeCodeType() {
+        return new TaxTypeCodeType();
+    }
+
+    /**
+     * Create an instance of {@link AmountType }
+     * 
+     */
+    public AmountType createAmountType() {
+        return new AmountType();
+    }
+
+    /**
+     * Create an instance of {@link CodeType }
+     * 
+     */
+    public CodeType createCodeType() {
+        return new CodeType();
+    }
+
+    /**
+     * Create an instance of {@link IDType }
+     * 
+     */
+    public IDType createIDType() {
+        return new IDType();
+    }
+
+    /**
+     * Create an instance of {@link IndicatorType }
+     * 
+     */
+    public IndicatorType createIndicatorType() {
+        return new IndicatorType();
+    }
+
+    /**
+     * Create an instance of {@link MeasureType }
+     * 
+     */
+    public MeasureType createMeasureType() {
+        return new MeasureType();
+    }
+
+    /**
+     * Create an instance of {@link NumericType }
+     * 
+     */
+    public NumericType createNumericType() {
+        return new NumericType();
+    }
+
+    /**
+     * Create an instance of {@link PercentType }
+     * 
+     */
+    public PercentType createPercentType() {
+        return new PercentType();
+    }
+
+    /**
+     * Create an instance of {@link QuantityType }
+     * 
+     */
+    public QuantityType createQuantityType() {
+        return new QuantityType();
+    }
+
+    /**
+     * Create an instance of {@link TextType }
+     * 
+     */
+    public TextType createTextType() {
+        return new TextType();
+    }
+
+    /**
+     * Create an instance of {@link CreditorFinancialAccountType }
+     * 
+     */
+    public CreditorFinancialAccountType createCreditorFinancialAccountType() {
+        return new CreditorFinancialAccountType();
+    }
+
+    /**
+     * Create an instance of {@link CreditorFinancialInstitutionType }
+     * 
+     */
+    public CreditorFinancialInstitutionType createCreditorFinancialInstitutionType() {
+        return new CreditorFinancialInstitutionType();
+    }
+
+    /**
+     * Create an instance of {@link DebtorFinancialAccountType }
+     * 
+     */
+    public DebtorFinancialAccountType createDebtorFinancialAccountType() {
+        return new DebtorFinancialAccountType();
+    }
+
+    /**
+     * Create an instance of {@link DebtorFinancialInstitutionType }
+     * 
+     */
+    public DebtorFinancialInstitutionType createDebtorFinancialInstitutionType() {
+        return new DebtorFinancialInstitutionType();
+    }
+
+    /**
+     * Create an instance of {@link DocumentContextParameterType }
+     * 
+     */
+    public DocumentContextParameterType createDocumentContextParameterType() {
+        return new DocumentContextParameterType();
+    }
+
+    /**
+     * Create an instance of {@link DocumentLineDocumentType }
+     * 
+     */
+    public DocumentLineDocumentType createDocumentLineDocumentType() {
+        return new DocumentLineDocumentType();
+    }
+
+    /**
+     * Create an instance of {@link ExchangedDocumentContextType }
+     * 
+     */
+    public ExchangedDocumentContextType createExchangedDocumentContextType() {
+        return new ExchangedDocumentContextType();
+    }
+
+    /**
+     * Create an instance of {@link ExchangedDocumentType }
+     * 
+     */
+    public ExchangedDocumentType createExchangedDocumentType() {
+        return new ExchangedDocumentType();
+    }
+
+    /**
+     * Create an instance of {@link LogisticsServiceChargeType }
+     * 
+     */
+    public LogisticsServiceChargeType createLogisticsServiceChargeType() {
+        return new LogisticsServiceChargeType();
+    }
+
+    /**
+     * Create an instance of {@link LogisticsTransportMovementType }
+     * 
+     */
+    public LogisticsTransportMovementType createLogisticsTransportMovementType() {
+        return new LogisticsTransportMovementType();
+    }
+
+    /**
+     * Create an instance of {@link NoteType }
+     * 
+     */
+    public NoteType createNoteType() {
+        return new NoteType();
+    }
+
+    /**
+     * Create an instance of {@link ProductCharacteristicType }
+     * 
+     */
+    public ProductCharacteristicType createProductCharacteristicType() {
+        return new ProductCharacteristicType();
+    }
+
+    /**
+     * Create an instance of {@link ProductClassificationType }
+     * 
+     */
+    public ProductClassificationType createProductClassificationType() {
+        return new ProductClassificationType();
+    }
+
+    /**
+     * Create an instance of {@link ReferencedDocumentType }
+     * 
+     */
+    public ReferencedDocumentType createReferencedDocumentType() {
+        return new ReferencedDocumentType();
+    }
+
+    /**
+     * Create an instance of {@link ReferencedProductType }
+     * 
+     */
+    public ReferencedProductType createReferencedProductType() {
+        return new ReferencedProductType();
+    }
+
+    /**
+     * Create an instance of {@link SpecifiedPeriodType }
+     * 
+     */
+    public SpecifiedPeriodType createSpecifiedPeriodType() {
+        return new SpecifiedPeriodType();
+    }
+
+    /**
+     * Create an instance of {@link SupplyChainConsignmentType }
+     * 
+     */
+    public SupplyChainConsignmentType createSupplyChainConsignmentType() {
+        return new SupplyChainConsignmentType();
+    }
+
+    /**
+     * Create an instance of {@link SupplyChainEventType }
+     * 
+     */
+    public SupplyChainEventType createSupplyChainEventType() {
+        return new SupplyChainEventType();
+    }
+
+    /**
+     * Create an instance of {@link SupplyChainTradeAgreementType }
+     * 
+     */
+    public SupplyChainTradeAgreementType createSupplyChainTradeAgreementType() {
+        return new SupplyChainTradeAgreementType();
+    }
+
+    /**
+     * Create an instance of {@link SupplyChainTradeDeliveryType }
+     * 
+     */
+    public SupplyChainTradeDeliveryType createSupplyChainTradeDeliveryType() {
+        return new SupplyChainTradeDeliveryType();
+    }
+
+    /**
+     * Create an instance of {@link SupplyChainTradeLineItemType }
+     * 
+     */
+    public SupplyChainTradeLineItemType createSupplyChainTradeLineItemType() {
+        return new SupplyChainTradeLineItemType();
+    }
+
+    /**
+     * Create an instance of {@link SupplyChainTradeSettlementType }
+     * 
+     */
+    public SupplyChainTradeSettlementType createSupplyChainTradeSettlementType() {
+        return new SupplyChainTradeSettlementType();
+    }
+
+    /**
+     * Create an instance of {@link SupplyChainTradeTransactionType }
+     * 
+     */
+    public SupplyChainTradeTransactionType createSupplyChainTradeTransactionType() {
+        return new SupplyChainTradeTransactionType();
+    }
+
+    /**
+     * Create an instance of {@link TaxRegistrationType }
+     * 
+     */
+    public TaxRegistrationType createTaxRegistrationType() {
+        return new TaxRegistrationType();
+    }
+
+    /**
+     * Create an instance of {@link TradeAccountingAccountType }
+     * 
+     */
+    public TradeAccountingAccountType createTradeAccountingAccountType() {
+        return new TradeAccountingAccountType();
+    }
+
+    /**
+     * Create an instance of {@link TradeAddressType }
+     * 
+     */
+    public TradeAddressType createTradeAddressType() {
+        return new TradeAddressType();
+    }
+
+    /**
+     * Create an instance of {@link TradeAllowanceChargeType }
+     * 
+     */
+    public TradeAllowanceChargeType createTradeAllowanceChargeType() {
+        return new TradeAllowanceChargeType();
+    }
+
+    /**
+     * Create an instance of {@link TradeContactType }
+     * 
+     */
+    public TradeContactType createTradeContactType() {
+        return new TradeContactType();
+    }
+
+    /**
+     * Create an instance of {@link TradeCountryType }
+     * 
+     */
+    public TradeCountryType createTradeCountryType() {
+        return new TradeCountryType();
+    }
+
+    /**
+     * Create an instance of {@link TradeDeliveryTermsType }
+     * 
+     */
+    public TradeDeliveryTermsType createTradeDeliveryTermsType() {
+        return new TradeDeliveryTermsType();
+    }
+
+    /**
+     * Create an instance of {@link TradePartyType }
+     * 
+     */
+    public TradePartyType createTradePartyType() {
+        return new TradePartyType();
+    }
+
+    /**
+     * Create an instance of {@link TradePaymentDiscountTermsType }
+     * 
+     */
+    public TradePaymentDiscountTermsType createTradePaymentDiscountTermsType() {
+        return new TradePaymentDiscountTermsType();
+    }
+
+    /**
+     * Create an instance of {@link TradePaymentPenaltyTermsType }
+     * 
+     */
+    public TradePaymentPenaltyTermsType createTradePaymentPenaltyTermsType() {
+        return new TradePaymentPenaltyTermsType();
+    }
+
+    /**
+     * Create an instance of {@link TradePaymentTermsType }
+     * 
+     */
+    public TradePaymentTermsType createTradePaymentTermsType() {
+        return new TradePaymentTermsType();
+    }
+
+    /**
+     * Create an instance of {@link TradePriceType }
+     * 
+     */
+    public TradePriceType createTradePriceType() {
+        return new TradePriceType();
+    }
+
+    /**
+     * Create an instance of {@link TradeProductType }
+     * 
+     */
+    public TradeProductType createTradeProductType() {
+        return new TradeProductType();
+    }
+
+    /**
+     * Create an instance of {@link TradeSettlementMonetarySummationType }
+     * 
+     */
+    public TradeSettlementMonetarySummationType createTradeSettlementMonetarySummationType() {
+        return new TradeSettlementMonetarySummationType();
+    }
+
+    /**
+     * Create an instance of {@link TradeSettlementPaymentMeansType }
+     * 
+     */
+    public TradeSettlementPaymentMeansType createTradeSettlementPaymentMeansType() {
+        return new TradeSettlementPaymentMeansType();
+    }
+
+    /**
+     * Create an instance of {@link TradeTaxType }
+     * 
+     */
+    public TradeTaxType createTradeTaxType() {
+        return new TradeTaxType();
+    }
+
+    /**
+     * Create an instance of {@link UniversalCommunicationType }
+     * 
+     */
+    public UniversalCommunicationType createUniversalCommunicationType() {
+        return new UniversalCommunicationType();
+    }
+
+    /**
+     * Create an instance of {@link DateTimeType.DateTimeString }
+     * 
+     */
+    public DateTimeType.DateTimeString createDateTimeTypeDateTimeString() {
+        return new DateTimeType.DateTimeString();
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link CrossIndustryDocumentType }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "urn:ferd:CrossIndustryDocument:invoice:1p0", name = "CrossIndustryDocument")
+    public JAXBElement<CrossIndustryDocumentType> createCrossIndustryDocument(CrossIndustryDocumentType value) {
+        return new JAXBElement<CrossIndustryDocumentType>(_CrossIndustryDocument_QNAME, CrossIndustryDocumentType.class, null, value);
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/PaymentMeansCodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/PaymentMeansCodeType.java
@@ -1,0 +1,79 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r PaymentMeansCodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="PaymentMeansCodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;PaymentMeansCodeContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PaymentMeansCodeType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class PaymentMeansCodeType {
+    
+    public static final String BANKACCOUNT = "42";
+    public static final String NOTSPECIFIED = "1";
+    public static final String AUTOMATICCLEARING = "3";
+    public static final String CASH = "10";
+    public static final String CHECK = "20";
+    public static final String DEBITADVICE = "31";
+    public static final String CREDITCARD = "48";
+    public static final String DEBIT = "49";
+    public static final String COMPENSATION = "97";
+
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/PercentType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/PercentType.java
@@ -1,0 +1,67 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.math.BigDecimal;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+
+/**
+ * <p>Java-Klasse f�r PercentType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="PercentType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;decimal"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PercentType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class PercentType {
+
+    @XmlValue
+    protected BigDecimal value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ProductCharacteristicType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ProductCharacteristicType.java
@@ -1,0 +1,175 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r ProductCharacteristicType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="ProductCharacteristicType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="TypeCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}CodeType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="Description" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ValueMeasure" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}MeasureType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="Value" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ProductCharacteristicType", propOrder = {
+    "typeCode",
+    "description",
+    "valueMeasure",
+    "value"
+})
+public class ProductCharacteristicType {
+
+    @XmlElement(name = "TypeCode")
+    protected List<CodeType> typeCode;
+    @XmlElement(name = "Description")
+    protected List<TextType> description;
+    @XmlElement(name = "ValueMeasure")
+    protected List<MeasureType> valueMeasure;
+    @XmlElement(name = "Value")
+    protected List<TextType> value;
+
+    /**
+     * Gets the value of the typeCode property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the typeCode property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getTypeCode().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link CodeType }
+     * 
+     * 
+     */
+    public List<CodeType> getTypeCode() {
+        if (typeCode == null) {
+            typeCode = new ArrayList<CodeType>();
+        }
+        return this.typeCode;
+    }
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the description property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDescription().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getDescription() {
+        if (description == null) {
+            description = new ArrayList<TextType>();
+        }
+        return this.description;
+    }
+
+    /**
+     * Gets the value of the valueMeasure property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the valueMeasure property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getValueMeasure().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link MeasureType }
+     * 
+     * 
+     */
+    public List<MeasureType> getValueMeasure() {
+        if (valueMeasure == null) {
+            valueMeasure = new ArrayList<MeasureType>();
+        }
+        return this.valueMeasure;
+    }
+
+    /**
+     * Gets the value of the value property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the value property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getValue().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getValue() {
+        if (value == null) {
+            value = new ArrayList<TextType>();
+        }
+        return this.value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ProductClassificationType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ProductClassificationType.java
@@ -1,0 +1,104 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r ProductClassificationType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="ProductClassificationType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ClassCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}CodeType" minOccurs="0"/&gt;
+ *         &lt;element name="ClassName" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ProductClassificationType", propOrder = {
+    "classCode",
+    "className"
+})
+public class ProductClassificationType {
+
+    @XmlElement(name = "ClassCode")
+    protected CodeType classCode;
+    @XmlElement(name = "ClassName")
+    protected List<TextType> className;
+
+    /**
+     * Ruft den Wert der classCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CodeType }
+     *     
+     */
+    public CodeType getClassCode() {
+        return classCode;
+    }
+
+    /**
+     * Legt den Wert der classCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CodeType }
+     *     
+     */
+    public void setClassCode(CodeType value) {
+        this.classCode = value;
+    }
+
+    /**
+     * Gets the value of the className property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the className property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getClassName().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getClassName() {
+        if (className == null) {
+            className = new ArrayList<TextType>();
+        }
+        return this.className;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/QuantityType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/QuantityType.java
@@ -1,0 +1,120 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.math.BigDecimal;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r QuantityType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="QuantityType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;decimal"&gt;
+ *       &lt;attribute name="unitCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}QuantityTypeUnitCodeContentType" /&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "QuantityType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class QuantityType {
+    
+    public static final String PIECE = "C62";
+    public static final String DAY = "DAY";
+    public static final String HECTARE = "HAR";
+    public static final String HOUR = "HUR";
+    public static final String KILOGRAM = "KGM";
+    public static final String KILOMETER = "KTM";
+    public static final String KILOWATTHOUR = "KWH";
+    public static final String FIXEDRATE = "LS";
+    public static final String LITRE = "LTR";
+    public static final String MINUTE = "MIN";
+    public static final String SQUAREMILLIMETER = "MMK";
+    public static final String MILLIMETER = "MMT";
+    public static final String SQUAREMETER = "MTK";
+    public static final String CUBICMETER = "MTQ";
+    public static final String METER = "MTR";
+    public static final String PRODUCTCOUNT = "NAR";
+    public static final String PRODUCTPAIR = "NPR";
+    public static final String PERCENT = "P1";
+    public static final String SET = "SET";
+    public static final String TON = "TNE";
+    public static final String WEEK = "WEE";
+
+    @XmlValue
+    protected BigDecimal value;
+    @XmlAttribute(name = "unitCode")
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String unitCode;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link BigDecimal }
+     *     
+     */
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    /**
+     * Ruft den Wert der unitCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getUnitCode() {
+        return unitCode;
+    }
+
+    /**
+     * Legt den Wert der unitCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setUnitCode(String value) {
+        this.unitCode = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ReferenceCodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ReferenceCodeType.java
@@ -1,0 +1,69 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r ReferenceCodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="ReferenceCodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;ReferenceCodeContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ReferenceCodeType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class ReferenceCodeType {
+
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ReferencedDocumentType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ReferencedDocumentType.java
@@ -1,0 +1,190 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r ReferencedDocumentType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="ReferencedDocumentType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="IssueDateTime" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}DateMandatoryDateTimeType" minOccurs="0"/&gt;
+ *         &lt;element name="LineID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="TypeCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}DocumentCodeType" minOccurs="0"/&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ReferenceTypeCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}ReferenceCodeType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ReferencedDocumentType", propOrder = {
+    "issueDateTime",
+    "lineID",
+    "typeCode",
+    "id",
+    "referenceTypeCode"
+})
+public class ReferencedDocumentType {
+
+    @XmlElement(name = "IssueDateTime")
+    @XmlSchemaType(name = "anySimpleType")
+    protected String issueDateTime;
+    @XmlElement(name = "LineID")
+    protected IDType lineID;
+    @XmlElement(name = "TypeCode")
+    protected DocumentCodeType typeCode;
+    @XmlElement(name = "ID")
+    protected List<IDType> id;
+    @XmlElement(name = "ReferenceTypeCode")
+    protected ReferenceCodeType referenceTypeCode;
+
+    /**
+     * Ruft den Wert der issueDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getIssueDateTime() {
+        return issueDateTime;
+    }
+
+    /**
+     * Legt den Wert der issueDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setIssueDateTime(String value) {
+        this.issueDateTime = value;
+    }
+
+    /**
+     * Ruft den Wert der lineID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getLineID() {
+        return lineID;
+    }
+
+    /**
+     * Legt den Wert der lineID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setLineID(IDType value) {
+        this.lineID = value;
+    }
+
+    /**
+     * Ruft den Wert der typeCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DocumentCodeType }
+     *     
+     */
+    public DocumentCodeType getTypeCode() {
+        return typeCode;
+    }
+
+    /**
+     * Legt den Wert der typeCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DocumentCodeType }
+     *     
+     */
+    public void setTypeCode(DocumentCodeType value) {
+        this.typeCode = value;
+    }
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the id property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link IDType }
+     * 
+     * 
+     */
+    public List<IDType> getID() {
+        if (id == null) {
+            id = new ArrayList<IDType>();
+        }
+        return this.id;
+    }
+
+    /**
+     * Ruft den Wert der referenceTypeCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ReferenceCodeType }
+     *     
+     */
+    public ReferenceCodeType getReferenceTypeCode() {
+        return referenceTypeCode;
+    }
+
+    /**
+     * Legt den Wert der referenceTypeCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ReferenceCodeType }
+     *     
+     */
+    public void setReferenceTypeCode(ReferenceCodeType value) {
+        this.referenceTypeCode = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ReferencedProductType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/ReferencedProductType.java
@@ -1,0 +1,231 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r ReferencedProductType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="ReferencedProductType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="GlobalID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SellerAssignedID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="BuyerAssignedID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="Name" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="Description" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="UnitQuantity" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}QuantityType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ReferencedProductType", propOrder = {
+    "globalID",
+    "sellerAssignedID",
+    "buyerAssignedID",
+    "name",
+    "description",
+    "unitQuantity"
+})
+public class ReferencedProductType {
+
+    @XmlElement(name = "GlobalID")
+    protected List<IDType> globalID;
+    @XmlElement(name = "SellerAssignedID")
+    protected IDType sellerAssignedID;
+    @XmlElement(name = "BuyerAssignedID")
+    protected IDType buyerAssignedID;
+    @XmlElement(name = "Name")
+    protected List<TextType> name;
+    @XmlElement(name = "Description")
+    protected List<TextType> description;
+    @XmlElement(name = "UnitQuantity")
+    protected List<QuantityType> unitQuantity;
+
+    /**
+     * Gets the value of the globalID property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the globalID property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getGlobalID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link IDType }
+     * 
+     * 
+     */
+    public List<IDType> getGlobalID() {
+        if (globalID == null) {
+            globalID = new ArrayList<IDType>();
+        }
+        return this.globalID;
+    }
+
+    /**
+     * Ruft den Wert der sellerAssignedID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getSellerAssignedID() {
+        return sellerAssignedID;
+    }
+
+    /**
+     * Legt den Wert der sellerAssignedID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setSellerAssignedID(IDType value) {
+        this.sellerAssignedID = value;
+    }
+
+    /**
+     * Ruft den Wert der buyerAssignedID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getBuyerAssignedID() {
+        return buyerAssignedID;
+    }
+
+    /**
+     * Legt den Wert der buyerAssignedID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setBuyerAssignedID(IDType value) {
+        this.buyerAssignedID = value;
+    }
+
+    /**
+     * Gets the value of the name property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the name property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getName().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getName() {
+        if (name == null) {
+            name = new ArrayList<TextType>();
+        }
+        return this.name;
+    }
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the description property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDescription().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getDescription() {
+        if (description == null) {
+            description = new ArrayList<TextType>();
+        }
+        return this.description;
+    }
+
+    /**
+     * Gets the value of the unitQuantity property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the unitQuantity property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getUnitQuantity().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link QuantityType }
+     * 
+     * 
+     */
+    public List<QuantityType> getUnitQuantity() {
+        if (unitQuantity == null) {
+            unitQuantity = new ArrayList<QuantityType>();
+        }
+        return this.unitQuantity;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SpecifiedPeriodType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SpecifiedPeriodType.java
@@ -1,0 +1,125 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SpecifiedPeriodType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * <complexType name="SpecifiedPeriodType">
+ *   <complexContent>
+ *     <restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       <sequence>
+ *         <element name="StartDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" minOccurs="0"/>
+ *         <element name="EndDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" minOccurs="0"/>
+ *         <element name="CompleteDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" minOccurs="0"/>
+ *       </sequence>
+ *     </restriction>
+ *   </complexContent>
+ * </complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SpecifiedPeriodType", propOrder = {
+    "startDateTime",
+    "endDateTime",
+    "completeDateTime"
+})
+public class SpecifiedPeriodType {
+
+    @XmlElement(name = "StartDateTime")
+    protected DateTimeType startDateTime;
+    @XmlElement(name = "EndDateTime")
+    protected DateTimeType endDateTime;
+    @XmlElement(name = "CompleteDateTime")
+    protected DateTimeType completeDateTime;
+
+    /**
+     * Ruft den Wert der startDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public DateTimeType getStartDateTime() {
+        return startDateTime;
+    }
+
+    /**
+     * Legt den Wert der startDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public void setStartDateTime(DateTimeType value) {
+        this.startDateTime = value;
+    }
+
+    /**
+     * Ruft den Wert der endDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public DateTimeType getEndDateTime() {
+        return endDateTime;
+    }
+
+    /**
+     * Legt den Wert der endDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public void setEndDateTime(DateTimeType value) {
+        this.endDateTime = value;
+    }
+
+    /**
+     * Ruft den Wert der completeDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public DateTimeType getCompleteDateTime() {
+        return completeDateTime;
+    }
+
+    /**
+     * Legt den Wert der completeDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public void setCompleteDateTime(DateTimeType value) {
+        this.completeDateTime = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainConsignmentType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainConsignmentType.java
@@ -1,0 +1,76 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SupplyChainConsignmentType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="SupplyChainConsignmentType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="SpecifiedLogisticsTransportMovement" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}LogisticsTransportMovementType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SupplyChainConsignmentType", propOrder = {
+    "specifiedLogisticsTransportMovement"
+})
+public class SupplyChainConsignmentType {
+
+    @XmlElement(name = "SpecifiedLogisticsTransportMovement")
+    protected List<LogisticsTransportMovementType> specifiedLogisticsTransportMovement;
+
+    /**
+     * Gets the value of the specifiedLogisticsTransportMovement property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the specifiedLogisticsTransportMovement property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getSpecifiedLogisticsTransportMovement().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link LogisticsTransportMovementType }
+     * 
+     * 
+     */
+    public List<LogisticsTransportMovementType> getSpecifiedLogisticsTransportMovement() {
+        if (specifiedLogisticsTransportMovement == null) {
+            specifiedLogisticsTransportMovement = new ArrayList<LogisticsTransportMovementType>();
+        }
+        return this.specifiedLogisticsTransportMovement;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainEventType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainEventType.java
@@ -1,0 +1,76 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SupplyChainEventType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="SupplyChainEventType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="OccurrenceDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SupplyChainEventType", propOrder = {
+    "occurrenceDateTime"
+})
+public class SupplyChainEventType {
+
+    @XmlElement(name = "OccurrenceDateTime")
+    protected List<DateTimeType> occurrenceDateTime;
+
+    /**
+     * Gets the value of the occurrenceDateTime property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the occurrenceDateTime property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getOccurrenceDateTime().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link DateTimeType }
+     * 
+     * 
+     */
+    public List<DateTimeType> getOccurrenceDateTime() {
+        if (occurrenceDateTime == null) {
+            occurrenceDateTime = new ArrayList<DateTimeType>();
+        }
+        return this.occurrenceDateTime;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeAgreementType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeAgreementType.java
@@ -1,0 +1,386 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SupplyChainTradeAgreementType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="SupplyChainTradeAgreementType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="BuyerReference" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SellerTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" minOccurs="0"/&gt;
+ *         &lt;element name="BuyerTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" minOccurs="0"/&gt;
+ *         &lt;element name="ProductEndUserTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicableTradeDeliveryTerms" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeDeliveryTermsType" minOccurs="0"/&gt;
+ *         &lt;element name="BuyerOrderReferencedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedDocumentType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ContractReferencedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedDocumentType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="AdditionalReferencedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedDocumentType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="GrossPriceProductTradePrice" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePriceType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="NetPriceProductTradePrice" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePriceType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="CustomerOrderReferencedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedDocumentType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SupplyChainTradeAgreementType", propOrder = {
+    "buyerReference",
+    "sellerTradeParty",
+    "buyerTradeParty",
+    "productEndUserTradeParty",
+    "applicableTradeDeliveryTerms",
+    "buyerOrderReferencedDocument",
+    "contractReferencedDocument",
+    "additionalReferencedDocument",
+    "grossPriceProductTradePrice",
+    "netPriceProductTradePrice",
+    "customerOrderReferencedDocument"
+})
+public class SupplyChainTradeAgreementType {
+
+    @XmlElement(name = "BuyerReference")
+    protected List<TextType> buyerReference;
+    @XmlElement(name = "SellerTradeParty")
+    protected TradePartyType sellerTradeParty;
+    @XmlElement(name = "BuyerTradeParty")
+    protected TradePartyType buyerTradeParty;
+    @XmlElement(name = "ProductEndUserTradeParty")
+    protected TradePartyType productEndUserTradeParty;
+    @XmlElement(name = "ApplicableTradeDeliveryTerms")
+    protected TradeDeliveryTermsType applicableTradeDeliveryTerms;
+    @XmlElement(name = "BuyerOrderReferencedDocument")
+    protected List<ReferencedDocumentType> buyerOrderReferencedDocument;
+    @XmlElement(name = "ContractReferencedDocument")
+    protected List<ReferencedDocumentType> contractReferencedDocument;
+    @XmlElement(name = "AdditionalReferencedDocument")
+    protected List<ReferencedDocumentType> additionalReferencedDocument;
+    @XmlElement(name = "GrossPriceProductTradePrice")
+    protected List<TradePriceType> grossPriceProductTradePrice;
+    @XmlElement(name = "NetPriceProductTradePrice")
+    protected List<TradePriceType> netPriceProductTradePrice;
+    @XmlElement(name = "CustomerOrderReferencedDocument")
+    protected List<ReferencedDocumentType> customerOrderReferencedDocument;
+
+    /**
+     * Gets the value of the buyerReference property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the buyerReference property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getBuyerReference().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getBuyerReference() {
+        if (buyerReference == null) {
+            buyerReference = new ArrayList<TextType>();
+        }
+        return this.buyerReference;
+    }
+
+    /**
+     * Ruft den Wert der sellerTradeParty-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public TradePartyType getSellerTradeParty() {
+        return sellerTradeParty;
+    }
+
+    /**
+     * Legt den Wert der sellerTradeParty-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public void setSellerTradeParty(TradePartyType value) {
+        this.sellerTradeParty = value;
+    }
+
+    /**
+     * Ruft den Wert der buyerTradeParty-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public TradePartyType getBuyerTradeParty() {
+        return buyerTradeParty;
+    }
+
+    /**
+     * Legt den Wert der buyerTradeParty-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public void setBuyerTradeParty(TradePartyType value) {
+        this.buyerTradeParty = value;
+    }
+
+    /**
+     * Ruft den Wert der productEndUserTradeParty-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public TradePartyType getProductEndUserTradeParty() {
+        return productEndUserTradeParty;
+    }
+
+    /**
+     * Legt den Wert der productEndUserTradeParty-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public void setProductEndUserTradeParty(TradePartyType value) {
+        this.productEndUserTradeParty = value;
+    }
+
+    /**
+     * Ruft den Wert der applicableTradeDeliveryTerms-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradeDeliveryTermsType }
+     *     
+     */
+    public TradeDeliveryTermsType getApplicableTradeDeliveryTerms() {
+        return applicableTradeDeliveryTerms;
+    }
+
+    /**
+     * Legt den Wert der applicableTradeDeliveryTerms-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradeDeliveryTermsType }
+     *     
+     */
+    public void setApplicableTradeDeliveryTerms(TradeDeliveryTermsType value) {
+        this.applicableTradeDeliveryTerms = value;
+    }
+
+    /**
+     * Gets the value of the buyerOrderReferencedDocument property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the buyerOrderReferencedDocument property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getBuyerOrderReferencedDocument().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ReferencedDocumentType }
+     * 
+     * 
+     */
+    public List<ReferencedDocumentType> getBuyerOrderReferencedDocument() {
+        if (buyerOrderReferencedDocument == null) {
+            buyerOrderReferencedDocument = new ArrayList<ReferencedDocumentType>();
+        }
+        return this.buyerOrderReferencedDocument;
+    }
+
+    /**
+     * Gets the value of the contractReferencedDocument property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the contractReferencedDocument property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getContractReferencedDocument().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ReferencedDocumentType }
+     * 
+     * 
+     */
+    public List<ReferencedDocumentType> getContractReferencedDocument() {
+        if (contractReferencedDocument == null) {
+            contractReferencedDocument = new ArrayList<ReferencedDocumentType>();
+        }
+        return this.contractReferencedDocument;
+    }
+
+    /**
+     * Gets the value of the additionalReferencedDocument property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the additionalReferencedDocument property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getAdditionalReferencedDocument().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ReferencedDocumentType }
+     * 
+     * 
+     */
+    public List<ReferencedDocumentType> getAdditionalReferencedDocument() {
+        if (additionalReferencedDocument == null) {
+            additionalReferencedDocument = new ArrayList<ReferencedDocumentType>();
+        }
+        return this.additionalReferencedDocument;
+    }
+
+    /**
+     * Gets the value of the grossPriceProductTradePrice property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the grossPriceProductTradePrice property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getGrossPriceProductTradePrice().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradePriceType }
+     * 
+     * 
+     */
+    public List<TradePriceType> getGrossPriceProductTradePrice() {
+        if (grossPriceProductTradePrice == null) {
+            grossPriceProductTradePrice = new ArrayList<TradePriceType>();
+        }
+        return this.grossPriceProductTradePrice;
+    }
+
+    /**
+     * Gets the value of the netPriceProductTradePrice property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the netPriceProductTradePrice property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getNetPriceProductTradePrice().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradePriceType }
+     * 
+     * 
+     */
+    public List<TradePriceType> getNetPriceProductTradePrice() {
+        if (netPriceProductTradePrice == null) {
+            netPriceProductTradePrice = new ArrayList<TradePriceType>();
+        }
+        return this.netPriceProductTradePrice;
+    }
+
+    /**
+     * Gets the value of the customerOrderReferencedDocument property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the customerOrderReferencedDocument property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getCustomerOrderReferencedDocument().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ReferencedDocumentType }
+     * 
+     * 
+     */
+    public List<ReferencedDocumentType> getCustomerOrderReferencedDocument() {
+        if (customerOrderReferencedDocument == null) {
+            customerOrderReferencedDocument = new ArrayList<ReferencedDocumentType>();
+        }
+        return this.customerOrderReferencedDocument;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeDeliveryType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeDeliveryType.java
@@ -1,0 +1,366 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SupplyChainTradeDeliveryType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="SupplyChainTradeDeliveryType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="BilledQuantity" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}QuantityType" minOccurs="0"/&gt;
+ *         &lt;element name="ChargeFreeQuantity" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}QuantityType" minOccurs="0"/&gt;
+ *         &lt;element name="PackageQuantity" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}QuantityType" minOccurs="0"/&gt;
+ *         &lt;element name="RelatedSupplyChainConsignment" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainConsignmentType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ShipToTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" minOccurs="0"/&gt;
+ *         &lt;element name="UltimateShipToTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" minOccurs="0"/&gt;
+ *         &lt;element name="ShipFromTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" minOccurs="0"/&gt;
+ *         &lt;element name="ActualDeliverySupplyChainEvent" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainEventType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="DespatchAdviceReferencedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedDocumentType" minOccurs="0"/&gt;
+ *         &lt;element name="ReceivingAdviceReferencedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedDocumentType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="DeliveryNoteReferencedDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedDocumentType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SupplyChainTradeDeliveryType", propOrder = {
+    "billedQuantity",
+    "chargeFreeQuantity",
+    "packageQuantity",
+    "relatedSupplyChainConsignment",
+    "shipToTradeParty",
+    "ultimateShipToTradeParty",
+    "shipFromTradeParty",
+    "actualDeliverySupplyChainEvent",
+    "despatchAdviceReferencedDocument",
+    "receivingAdviceReferencedDocument",
+    "deliveryNoteReferencedDocument"
+})
+public class SupplyChainTradeDeliveryType {
+
+    @XmlElement(name = "BilledQuantity")
+    protected QuantityType billedQuantity;
+    @XmlElement(name = "ChargeFreeQuantity")
+    protected QuantityType chargeFreeQuantity;
+    @XmlElement(name = "PackageQuantity")
+    protected QuantityType packageQuantity;
+    @XmlElement(name = "RelatedSupplyChainConsignment")
+    protected List<SupplyChainConsignmentType> relatedSupplyChainConsignment;
+    @XmlElement(name = "ShipToTradeParty")
+    protected TradePartyType shipToTradeParty;
+    @XmlElement(name = "UltimateShipToTradeParty")
+    protected TradePartyType ultimateShipToTradeParty;
+    @XmlElement(name = "ShipFromTradeParty")
+    protected TradePartyType shipFromTradeParty;
+    @XmlElement(name = "ActualDeliverySupplyChainEvent")
+    protected List<SupplyChainEventType> actualDeliverySupplyChainEvent;
+    @XmlElement(name = "DespatchAdviceReferencedDocument")
+    protected ReferencedDocumentType despatchAdviceReferencedDocument;
+    @XmlElement(name = "ReceivingAdviceReferencedDocument")
+    protected List<ReferencedDocumentType> receivingAdviceReferencedDocument;
+    @XmlElement(name = "DeliveryNoteReferencedDocument")
+    protected ReferencedDocumentType deliveryNoteReferencedDocument;
+
+    /**
+     * Ruft den Wert der billedQuantity-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QuantityType }
+     *     
+     */
+    public QuantityType getBilledQuantity() {
+        return billedQuantity;
+    }
+
+    /**
+     * Legt den Wert der billedQuantity-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QuantityType }
+     *     
+     */
+    public void setBilledQuantity(QuantityType value) {
+        this.billedQuantity = value;
+    }
+
+    /**
+     * Ruft den Wert der chargeFreeQuantity-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QuantityType }
+     *     
+     */
+    public QuantityType getChargeFreeQuantity() {
+        return chargeFreeQuantity;
+    }
+
+    /**
+     * Legt den Wert der chargeFreeQuantity-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QuantityType }
+     *     
+     */
+    public void setChargeFreeQuantity(QuantityType value) {
+        this.chargeFreeQuantity = value;
+    }
+
+    /**
+     * Ruft den Wert der packageQuantity-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QuantityType }
+     *     
+     */
+    public QuantityType getPackageQuantity() {
+        return packageQuantity;
+    }
+
+    /**
+     * Legt den Wert der packageQuantity-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QuantityType }
+     *     
+     */
+    public void setPackageQuantity(QuantityType value) {
+        this.packageQuantity = value;
+    }
+
+    /**
+     * Gets the value of the relatedSupplyChainConsignment property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the relatedSupplyChainConsignment property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getRelatedSupplyChainConsignment().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link SupplyChainConsignmentType }
+     * 
+     * 
+     */
+    public List<SupplyChainConsignmentType> getRelatedSupplyChainConsignment() {
+        if (relatedSupplyChainConsignment == null) {
+            relatedSupplyChainConsignment = new ArrayList<SupplyChainConsignmentType>();
+        }
+        return this.relatedSupplyChainConsignment;
+    }
+
+    /**
+     * Ruft den Wert der shipToTradeParty-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public TradePartyType getShipToTradeParty() {
+        return shipToTradeParty;
+    }
+
+    /**
+     * Legt den Wert der shipToTradeParty-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public void setShipToTradeParty(TradePartyType value) {
+        this.shipToTradeParty = value;
+    }
+
+    /**
+     * Ruft den Wert der ultimateShipToTradeParty-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public TradePartyType getUltimateShipToTradeParty() {
+        return ultimateShipToTradeParty;
+    }
+
+    /**
+     * Legt den Wert der ultimateShipToTradeParty-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public void setUltimateShipToTradeParty(TradePartyType value) {
+        this.ultimateShipToTradeParty = value;
+    }
+
+    /**
+     * Ruft den Wert der shipFromTradeParty-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public TradePartyType getShipFromTradeParty() {
+        return shipFromTradeParty;
+    }
+
+    /**
+     * Legt den Wert der shipFromTradeParty-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public void setShipFromTradeParty(TradePartyType value) {
+        this.shipFromTradeParty = value;
+    }
+
+    /**
+     * Gets the value of the actualDeliverySupplyChainEvent property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the actualDeliverySupplyChainEvent property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getActualDeliverySupplyChainEvent().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link SupplyChainEventType }
+     * 
+     * 
+     */
+    public List<SupplyChainEventType> getActualDeliverySupplyChainEvent() {
+        if (actualDeliverySupplyChainEvent == null) {
+            actualDeliverySupplyChainEvent = new ArrayList<SupplyChainEventType>();
+        }
+        return this.actualDeliverySupplyChainEvent;
+    }
+
+    /**
+     * Ruft den Wert der despatchAdviceReferencedDocument-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ReferencedDocumentType }
+     *     
+     */
+    public ReferencedDocumentType getDespatchAdviceReferencedDocument() {
+        return despatchAdviceReferencedDocument;
+    }
+
+    /**
+     * Legt den Wert der despatchAdviceReferencedDocument-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ReferencedDocumentType }
+     *     
+     */
+    public void setDespatchAdviceReferencedDocument(ReferencedDocumentType value) {
+        this.despatchAdviceReferencedDocument = value;
+    }
+
+    /**
+     * Gets the value of the receivingAdviceReferencedDocument property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the receivingAdviceReferencedDocument property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getReceivingAdviceReferencedDocument().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ReferencedDocumentType }
+     * 
+     * 
+     */
+    public List<ReferencedDocumentType> getReceivingAdviceReferencedDocument() {
+        if (receivingAdviceReferencedDocument == null) {
+            receivingAdviceReferencedDocument = new ArrayList<ReferencedDocumentType>();
+        }
+        return this.receivingAdviceReferencedDocument;
+    }
+
+    /**
+     * Ruft den Wert der deliveryNoteReferencedDocument-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link ReferencedDocumentType }
+     *     
+     */
+    public ReferencedDocumentType getDeliveryNoteReferencedDocument() {
+        return deliveryNoteReferencedDocument;
+    }
+
+    /**
+     * Legt den Wert der deliveryNoteReferencedDocument-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link ReferencedDocumentType }
+     *     
+     */
+    public void setDeliveryNoteReferencedDocument(ReferencedDocumentType value) {
+        this.deliveryNoteReferencedDocument = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeLineItemType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeLineItemType.java
@@ -1,0 +1,181 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SupplyChainTradeLineItemType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="SupplyChainTradeLineItemType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="AssociatedDocumentLineDocument" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}DocumentLineDocumentType" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedSupplyChainTradeAgreement" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeAgreementType" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedSupplyChainTradeDelivery" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeDeliveryType" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedSupplyChainTradeSettlement" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeSettlementType" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedTradeProduct" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeProductType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SupplyChainTradeLineItemType", propOrder = {
+    "associatedDocumentLineDocument",
+    "specifiedSupplyChainTradeAgreement",
+    "specifiedSupplyChainTradeDelivery",
+    "specifiedSupplyChainTradeSettlement",
+    "specifiedTradeProduct"
+})
+public class SupplyChainTradeLineItemType {
+
+    @XmlElement(name = "AssociatedDocumentLineDocument")
+    protected DocumentLineDocumentType associatedDocumentLineDocument;
+    @XmlElement(name = "SpecifiedSupplyChainTradeAgreement")
+    protected SupplyChainTradeAgreementType specifiedSupplyChainTradeAgreement;
+    @XmlElement(name = "SpecifiedSupplyChainTradeDelivery")
+    protected SupplyChainTradeDeliveryType specifiedSupplyChainTradeDelivery;
+    @XmlElement(name = "SpecifiedSupplyChainTradeSettlement")
+    protected SupplyChainTradeSettlementType specifiedSupplyChainTradeSettlement;
+    @XmlElement(name = "SpecifiedTradeProduct")
+    protected TradeProductType specifiedTradeProduct;
+
+    /**
+     * Ruft den Wert der associatedDocumentLineDocument-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DocumentLineDocumentType }
+     *     
+     */
+    public DocumentLineDocumentType getAssociatedDocumentLineDocument() {
+        return associatedDocumentLineDocument;
+    }
+
+    /**
+     * Legt den Wert der associatedDocumentLineDocument-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DocumentLineDocumentType }
+     *     
+     */
+    public void setAssociatedDocumentLineDocument(DocumentLineDocumentType value) {
+        this.associatedDocumentLineDocument = value;
+    }
+
+    /**
+     * Ruft den Wert der specifiedSupplyChainTradeAgreement-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SupplyChainTradeAgreementType }
+     *     
+     */
+    public SupplyChainTradeAgreementType getSpecifiedSupplyChainTradeAgreement() {
+        return specifiedSupplyChainTradeAgreement;
+    }
+
+    /**
+     * Legt den Wert der specifiedSupplyChainTradeAgreement-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SupplyChainTradeAgreementType }
+     *     
+     */
+    public void setSpecifiedSupplyChainTradeAgreement(SupplyChainTradeAgreementType value) {
+        this.specifiedSupplyChainTradeAgreement = value;
+    }
+
+    /**
+     * Ruft den Wert der specifiedSupplyChainTradeDelivery-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SupplyChainTradeDeliveryType }
+     *     
+     */
+    public SupplyChainTradeDeliveryType getSpecifiedSupplyChainTradeDelivery() {
+        return specifiedSupplyChainTradeDelivery;
+    }
+
+    /**
+     * Legt den Wert der specifiedSupplyChainTradeDelivery-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SupplyChainTradeDeliveryType }
+     *     
+     */
+    public void setSpecifiedSupplyChainTradeDelivery(SupplyChainTradeDeliveryType value) {
+        this.specifiedSupplyChainTradeDelivery = value;
+    }
+
+    /**
+     * Ruft den Wert der specifiedSupplyChainTradeSettlement-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SupplyChainTradeSettlementType }
+     *     
+     */
+    public SupplyChainTradeSettlementType getSpecifiedSupplyChainTradeSettlement() {
+        return specifiedSupplyChainTradeSettlement;
+    }
+
+    /**
+     * Legt den Wert der specifiedSupplyChainTradeSettlement-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SupplyChainTradeSettlementType }
+     *     
+     */
+    public void setSpecifiedSupplyChainTradeSettlement(SupplyChainTradeSettlementType value) {
+        this.specifiedSupplyChainTradeSettlement = value;
+    }
+
+    /**
+     * Ruft den Wert der specifiedTradeProduct-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradeProductType }
+     *     
+     */
+    public TradeProductType getSpecifiedTradeProduct() {
+        return specifiedTradeProduct;
+    }
+
+    /**
+     * Legt den Wert der specifiedTradeProduct-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradeProductType }
+     *     
+     */
+    public void setSpecifiedTradeProduct(TradeProductType value) {
+        this.specifiedTradeProduct = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeSettlementType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeSettlementType.java
@@ -1,0 +1,457 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SupplyChainTradeSettlementType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="SupplyChainTradeSettlementType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="PaymentReference" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="InvoiceCurrencyCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}CodeType" minOccurs="0"/&gt;
+ *         &lt;element name="InvoiceeTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" minOccurs="0"/&gt;
+ *         &lt;element name="PayeeTradeParty" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePartyType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedTradeSettlementPaymentMeans" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeSettlementPaymentMeansType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicableTradeTax" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeTaxType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="BillingSpecifiedPeriod" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SpecifiedPeriodType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedTradeAllowanceCharge" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeAllowanceChargeType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedLogisticsServiceCharge" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}LogisticsServiceChargeType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedTradePaymentTerms" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePaymentTermsType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedTradeAccountingAccount" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeAccountingAccountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedTradeSettlementMonetarySummation" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeSettlementMonetarySummationType" minOccurs="0"/&gt;
+ *         &lt;element name="ReceivableSpecifiedTradeAccountingAccount" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeAccountingAccountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SupplyChainTradeSettlementType", propOrder = {
+    "paymentReference",
+    "invoiceCurrencyCode",
+    "invoiceeTradeParty",
+    "payeeTradeParty",
+    "specifiedTradeSettlementPaymentMeans",
+    "applicableTradeTax",
+    "billingSpecifiedPeriod",
+    "specifiedTradeAllowanceCharge",
+    "specifiedLogisticsServiceCharge",
+    "specifiedTradePaymentTerms",
+    "specifiedTradeAccountingAccount",
+    "specifiedTradeSettlementMonetarySummation",
+    "receivableSpecifiedTradeAccountingAccount"
+})
+public class SupplyChainTradeSettlementType {
+
+    @XmlElement(name = "PaymentReference")
+    protected List<TextType> paymentReference;
+    @XmlElement(name = "InvoiceCurrencyCode")
+    protected CodeType invoiceCurrencyCode;
+    @XmlElement(name = "InvoiceeTradeParty")
+    protected TradePartyType invoiceeTradeParty;
+    @XmlElement(name = "PayeeTradeParty")
+    protected List<TradePartyType> payeeTradeParty;
+    @XmlElement(name = "SpecifiedTradeSettlementPaymentMeans")
+    protected List<TradeSettlementPaymentMeansType> specifiedTradeSettlementPaymentMeans;
+    @XmlElement(name = "ApplicableTradeTax")
+    protected List<TradeTaxType> applicableTradeTax;
+    @XmlElement(name = "BillingSpecifiedPeriod")
+    protected List<SpecifiedPeriodType> billingSpecifiedPeriod;
+    @XmlElement(name = "SpecifiedTradeAllowanceCharge")
+    protected List<TradeAllowanceChargeType> specifiedTradeAllowanceCharge;
+    @XmlElement(name = "SpecifiedLogisticsServiceCharge")
+    protected List<LogisticsServiceChargeType> specifiedLogisticsServiceCharge;
+    @XmlElement(name = "SpecifiedTradePaymentTerms")
+    protected List<TradePaymentTermsType> specifiedTradePaymentTerms;
+    @XmlElement(name = "SpecifiedTradeAccountingAccount")
+    protected List<TradeAccountingAccountType> specifiedTradeAccountingAccount;
+    @XmlElement(name = "SpecifiedTradeSettlementMonetarySummation")
+    protected TradeSettlementMonetarySummationType specifiedTradeSettlementMonetarySummation;
+    @XmlElement(name = "ReceivableSpecifiedTradeAccountingAccount")
+    protected List<TradeAccountingAccountType> receivableSpecifiedTradeAccountingAccount;
+
+    /**
+     * Gets the value of the paymentReference property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the paymentReference property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getPaymentReference().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getPaymentReference() {
+        if (paymentReference == null) {
+            paymentReference = new ArrayList<TextType>();
+        }
+        return this.paymentReference;
+    }
+
+    /**
+     * Ruft den Wert der invoiceCurrencyCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CodeType }
+     *     
+     */
+    public CodeType getInvoiceCurrencyCode() {
+        return invoiceCurrencyCode;
+    }
+
+    /**
+     * Legt den Wert der invoiceCurrencyCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CodeType }
+     *     
+     */
+    public void setInvoiceCurrencyCode(CodeType value) {
+        this.invoiceCurrencyCode = value;
+    }
+
+    /**
+     * Ruft den Wert der invoiceeTradeParty-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public TradePartyType getInvoiceeTradeParty() {
+        return invoiceeTradeParty;
+    }
+
+    /**
+     * Legt den Wert der invoiceeTradeParty-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradePartyType }
+     *     
+     */
+    public void setInvoiceeTradeParty(TradePartyType value) {
+        this.invoiceeTradeParty = value;
+    }
+
+    /**
+     * Gets the value of the payeeTradeParty property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the payeeTradeParty property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getPayeeTradeParty().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradePartyType }
+     * 
+     * 
+     */
+    public List<TradePartyType> getPayeeTradeParty() {
+        if (payeeTradeParty == null) {
+            payeeTradeParty = new ArrayList<TradePartyType>();
+        }
+        return this.payeeTradeParty;
+    }
+
+    /**
+     * Gets the value of the specifiedTradeSettlementPaymentMeans property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the specifiedTradeSettlementPaymentMeans property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getSpecifiedTradeSettlementPaymentMeans().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeSettlementPaymentMeansType }
+     * 
+     * 
+     */
+    public List<TradeSettlementPaymentMeansType> getSpecifiedTradeSettlementPaymentMeans() {
+        if (specifiedTradeSettlementPaymentMeans == null) {
+            specifiedTradeSettlementPaymentMeans = new ArrayList<TradeSettlementPaymentMeansType>();
+        }
+        return this.specifiedTradeSettlementPaymentMeans;
+    }
+
+    /**
+     * Gets the value of the applicableTradeTax property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the applicableTradeTax property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getApplicableTradeTax().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeTaxType }
+     * 
+     * 
+     */
+    public List<TradeTaxType> getApplicableTradeTax() {
+        if (applicableTradeTax == null) {
+            applicableTradeTax = new ArrayList<TradeTaxType>();
+        }
+        return this.applicableTradeTax;
+    }
+
+    /**
+     * Gets the value of the billingSpecifiedPeriod property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the billingSpecifiedPeriod property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getBillingSpecifiedPeriod().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link SpecifiedPeriodType }
+     * 
+     * 
+     */
+    public List<SpecifiedPeriodType> getBillingSpecifiedPeriod() {
+        if (billingSpecifiedPeriod == null) {
+            billingSpecifiedPeriod = new ArrayList<SpecifiedPeriodType>();
+        }
+        return this.billingSpecifiedPeriod;
+    }
+
+    /**
+     * Gets the value of the specifiedTradeAllowanceCharge property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the specifiedTradeAllowanceCharge property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getSpecifiedTradeAllowanceCharge().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeAllowanceChargeType }
+     * 
+     * 
+     */
+    public List<TradeAllowanceChargeType> getSpecifiedTradeAllowanceCharge() {
+        if (specifiedTradeAllowanceCharge == null) {
+            specifiedTradeAllowanceCharge = new ArrayList<TradeAllowanceChargeType>();
+        }
+        return this.specifiedTradeAllowanceCharge;
+    }
+
+    /**
+     * Gets the value of the specifiedLogisticsServiceCharge property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the specifiedLogisticsServiceCharge property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getSpecifiedLogisticsServiceCharge().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link LogisticsServiceChargeType }
+     * 
+     * 
+     */
+    public List<LogisticsServiceChargeType> getSpecifiedLogisticsServiceCharge() {
+        if (specifiedLogisticsServiceCharge == null) {
+            specifiedLogisticsServiceCharge = new ArrayList<LogisticsServiceChargeType>();
+        }
+        return this.specifiedLogisticsServiceCharge;
+    }
+
+    /**
+     * Gets the value of the specifiedTradePaymentTerms property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the specifiedTradePaymentTerms property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getSpecifiedTradePaymentTerms().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradePaymentTermsType }
+     * 
+     * 
+     */
+    public List<TradePaymentTermsType> getSpecifiedTradePaymentTerms() {
+        if (specifiedTradePaymentTerms == null) {
+            specifiedTradePaymentTerms = new ArrayList<TradePaymentTermsType>();
+        }
+        return this.specifiedTradePaymentTerms;
+    }
+
+    /**
+     * Gets the value of the specifiedTradeAccountingAccount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the specifiedTradeAccountingAccount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getSpecifiedTradeAccountingAccount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeAccountingAccountType }
+     * 
+     * 
+     */
+    public List<TradeAccountingAccountType> getSpecifiedTradeAccountingAccount() {
+        if (specifiedTradeAccountingAccount == null) {
+            specifiedTradeAccountingAccount = new ArrayList<TradeAccountingAccountType>();
+        }
+        return this.specifiedTradeAccountingAccount;
+    }
+
+    /**
+     * Ruft den Wert der specifiedTradeSettlementMonetarySummation-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradeSettlementMonetarySummationType }
+     *     
+     */
+    public TradeSettlementMonetarySummationType getSpecifiedTradeSettlementMonetarySummation() {
+        return specifiedTradeSettlementMonetarySummation;
+    }
+
+    /**
+     * Legt den Wert der specifiedTradeSettlementMonetarySummation-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradeSettlementMonetarySummationType }
+     *     
+     */
+    public void setSpecifiedTradeSettlementMonetarySummation(TradeSettlementMonetarySummationType value) {
+        this.specifiedTradeSettlementMonetarySummation = value;
+    }
+
+    /**
+     * Gets the value of the receivableSpecifiedTradeAccountingAccount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the receivableSpecifiedTradeAccountingAccount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getReceivableSpecifiedTradeAccountingAccount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeAccountingAccountType }
+     * 
+     * 
+     */
+    public List<TradeAccountingAccountType> getReceivableSpecifiedTradeAccountingAccount() {
+        if (receivableSpecifiedTradeAccountingAccount == null) {
+            receivableSpecifiedTradeAccountingAccount = new ArrayList<TradeAccountingAccountType>();
+        }
+        return this.receivableSpecifiedTradeAccountingAccount;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeTransactionType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/SupplyChainTradeTransactionType.java
@@ -1,0 +1,165 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r SupplyChainTradeTransactionType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="SupplyChainTradeTransactionType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ApplicableSupplyChainTradeAgreement" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeAgreementType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicableSupplyChainTradeDelivery" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeDeliveryType" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicableSupplyChainTradeSettlement" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeSettlementType" minOccurs="0"/&gt;
+ *         &lt;element name="IncludedSupplyChainTradeLineItem" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}SupplyChainTradeLineItemType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SupplyChainTradeTransactionType", propOrder = {
+    "applicableSupplyChainTradeAgreement",
+    "applicableSupplyChainTradeDelivery",
+    "applicableSupplyChainTradeSettlement",
+    "includedSupplyChainTradeLineItem"
+})
+public class SupplyChainTradeTransactionType {
+
+    @XmlElement(name = "ApplicableSupplyChainTradeAgreement")
+    protected List<SupplyChainTradeAgreementType> applicableSupplyChainTradeAgreement;
+    @XmlElement(name = "ApplicableSupplyChainTradeDelivery")
+    protected SupplyChainTradeDeliveryType applicableSupplyChainTradeDelivery;
+    @XmlElement(name = "ApplicableSupplyChainTradeSettlement")
+    protected SupplyChainTradeSettlementType applicableSupplyChainTradeSettlement;
+    @XmlElement(name = "IncludedSupplyChainTradeLineItem")
+    protected List<SupplyChainTradeLineItemType> includedSupplyChainTradeLineItem;
+
+    /**
+     * Gets the value of the applicableSupplyChainTradeAgreement property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the applicableSupplyChainTradeAgreement property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getApplicableSupplyChainTradeAgreement().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link SupplyChainTradeAgreementType }
+     * 
+     * 
+     */
+    public List<SupplyChainTradeAgreementType> getApplicableSupplyChainTradeAgreement() {
+        if (applicableSupplyChainTradeAgreement == null) {
+            applicableSupplyChainTradeAgreement = new ArrayList<SupplyChainTradeAgreementType>();
+        }
+        return this.applicableSupplyChainTradeAgreement;
+    }
+
+    /**
+     * Ruft den Wert der applicableSupplyChainTradeDelivery-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SupplyChainTradeDeliveryType }
+     *     
+     */
+    public SupplyChainTradeDeliveryType getApplicableSupplyChainTradeDelivery() {
+        return applicableSupplyChainTradeDelivery;
+    }
+
+    /**
+     * Legt den Wert der applicableSupplyChainTradeDelivery-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SupplyChainTradeDeliveryType }
+     *     
+     */
+    public void setApplicableSupplyChainTradeDelivery(SupplyChainTradeDeliveryType value) {
+        this.applicableSupplyChainTradeDelivery = value;
+    }
+
+    /**
+     * Ruft den Wert der applicableSupplyChainTradeSettlement-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SupplyChainTradeSettlementType }
+     *     
+     */
+    public SupplyChainTradeSettlementType getApplicableSupplyChainTradeSettlement() {
+        return applicableSupplyChainTradeSettlement;
+    }
+
+    /**
+     * Legt den Wert der applicableSupplyChainTradeSettlement-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SupplyChainTradeSettlementType }
+     *     
+     */
+    public void setApplicableSupplyChainTradeSettlement(SupplyChainTradeSettlementType value) {
+        this.applicableSupplyChainTradeSettlement = value;
+    }
+
+    /**
+     * Gets the value of the includedSupplyChainTradeLineItem property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the includedSupplyChainTradeLineItem property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getIncludedSupplyChainTradeLineItem().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link SupplyChainTradeLineItemType }
+     * 
+     * 
+     */
+    public List<SupplyChainTradeLineItemType> getIncludedSupplyChainTradeLineItem() {
+        if (includedSupplyChainTradeLineItem == null) {
+            includedSupplyChainTradeLineItem = new ArrayList<SupplyChainTradeLineItemType>();
+        }
+        return this.includedSupplyChainTradeLineItem;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TaxCategoryCodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TaxCategoryCodeType.java
@@ -1,0 +1,76 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r TaxCategoryCodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TaxCategoryCodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;TaxCategoryCodeContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TaxCategoryCodeType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class TaxCategoryCodeType {
+
+    public static final String STANDARDRATE = "S";
+    public static final String REVERSECHARGE = "AE";
+    public static final String TAXEXEMPT = "E";
+    public static final String ZEROTAXPRODUCTS = "Z";
+    public static final String UNTAXEDSERVICE = "O";
+    public static final String INTRACOMMUNITY = "IC";
+    
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TaxRegistrationType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TaxRegistrationType.java
@@ -1,0 +1,72 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TaxRegistrationType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TaxRegistrationType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TaxRegistrationType", propOrder = {
+    "id"
+})
+public class TaxRegistrationType {
+    
+    public static final String USTID = "VA";
+    public static final String TAXID = "FC";
+
+    @XmlElement(name = "ID")
+    protected IDType id;
+
+    /**
+     * Ruft den Wert der id-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getID() {
+        return id;
+    }
+
+    /**
+     * Legt den Wert der id-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setID(IDType value) {
+        this.id = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TaxTypeCodeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TaxTypeCodeType.java
@@ -1,0 +1,73 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+
+/**
+ * <p>Java-Klasse f�r TaxTypeCodeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TaxTypeCodeType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;urn:un:unece:uncefact:data:standard:QualifiedDataType:12&gt;TaxTypeCodeContentType"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TaxTypeCodeType", namespace = "urn:un:unece:uncefact:data:standard:QualifiedDataType:12", propOrder = {
+    "value"
+})
+public class TaxTypeCodeType {
+    
+    public static final String SALESTAX = "VAT";
+    public static final String INSURANCETAX = "ZF_INSURANCE_TAX";
+    public static final String OLDPART = "AAJ";
+    
+    @XmlValue
+    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TextType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TextType.java
@@ -1,0 +1,66 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+
+/**
+ * <p>Java-Klasse f�r TextType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TextType"&gt;
+ *   &lt;simpleContent&gt;
+ *     &lt;extension base="&lt;http://www.w3.org/2001/XMLSchema&gt;string"&gt;
+ *     &lt;/extension&gt;
+ *   &lt;/simpleContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TextType", namespace = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", propOrder = {
+    "value"
+})
+public class TextType {
+
+    @XmlValue
+    protected String value;
+
+    /**
+     * Ruft den Wert der value-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Legt den Wert der value-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeAccountingAccountType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeAccountingAccountType.java
@@ -1,0 +1,69 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeAccountingAccountType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeAccountingAccountType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeAccountingAccountType", propOrder = {
+    "id"
+})
+public class TradeAccountingAccountType {
+
+    @XmlElement(name = "ID")
+    protected IDType id;
+
+    /**
+     * Ruft den Wert der id-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getID() {
+        return id;
+    }
+
+    /**
+     * Legt den Wert der id-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setID(IDType value) {
+        this.id = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeAddressType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeAddressType.java
@@ -1,0 +1,188 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeAddressType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeAddressType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="PostcodeCode" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}CodeType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="LineOne" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="LineTwo" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="CityName" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="CountryID" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}CountryIDType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeAddressType", propOrder = {
+    "postcodeCode",
+    "lineOne",
+    "lineTwo",
+    "cityName",
+    "countryID"
+})
+public class TradeAddressType {
+
+    @XmlElement(name = "PostcodeCode")
+    protected List<CodeType> postcodeCode;
+    @XmlElement(name = "LineOne")
+    protected TextType lineOne;
+    @XmlElement(name = "LineTwo")
+    protected TextType lineTwo;
+    @XmlElement(name = "CityName")
+    protected TextType cityName;
+    @XmlElement(name = "CountryID")
+    protected CountryIDType countryID;
+
+    /**
+     * Gets the value of the postcodeCode property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the postcodeCode property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getPostcodeCode().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link CodeType }
+     * 
+     * 
+     */
+    public List<CodeType> getPostcodeCode() {
+        if (postcodeCode == null) {
+            postcodeCode = new ArrayList<CodeType>();
+        }
+        return this.postcodeCode;
+    }
+
+    /**
+     * Ruft den Wert der lineOne-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getLineOne() {
+        return lineOne;
+    }
+
+    /**
+     * Legt den Wert der lineOne-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setLineOne(TextType value) {
+        this.lineOne = value;
+    }
+
+    /**
+     * Ruft den Wert der lineTwo-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getLineTwo() {
+        return lineTwo;
+    }
+
+    /**
+     * Legt den Wert der lineTwo-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setLineTwo(TextType value) {
+        this.lineTwo = value;
+    }
+
+    /**
+     * Ruft den Wert der cityName-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getCityName() {
+        return cityName;
+    }
+
+    /**
+     * Legt den Wert der cityName-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setCityName(TextType value) {
+        this.cityName = value;
+    }
+
+    /**
+     * Ruft den Wert der countryID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CountryIDType }
+     *     
+     */
+    public CountryIDType getCountryID() {
+        return countryID;
+    }
+
+    /**
+     * Legt den Wert der countryID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CountryIDType }
+     *     
+     */
+    public void setCountryID(CountryIDType value) {
+        this.countryID = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeAllowanceChargeType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeAllowanceChargeType.java
@@ -1,0 +1,305 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeAllowanceChargeType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeAllowanceChargeType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ChargeIndicator" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IndicatorType" minOccurs="0"/&gt;
+ *         &lt;element name="SequenceNumeric" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}NumericType" minOccurs="0"/&gt;
+ *         &lt;element name="CalculationPercent" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}PercentType" minOccurs="0"/&gt;
+ *         &lt;element name="BasisAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" minOccurs="0"/&gt;
+ *         &lt;element name="BasisQuantity" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}QuantityType" minOccurs="0"/&gt;
+ *         &lt;element name="ActualAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ReasonCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}AllowanceChargeReasonCodeType" minOccurs="0"/&gt;
+ *         &lt;element name="Reason" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="CategoryTradeTax" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeTaxType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeAllowanceChargeType", propOrder = {
+    "chargeIndicator",
+    "sequenceNumeric",
+    "calculationPercent",
+    "basisAmount",
+    "basisQuantity",
+    "actualAmount",
+    "reasonCode",
+    "reason",
+    "categoryTradeTax"
+})
+public class TradeAllowanceChargeType {
+
+    @XmlElement(name = "ChargeIndicator")
+    protected IndicatorType chargeIndicator;
+    @XmlElement(name = "SequenceNumeric")
+    protected NumericType sequenceNumeric;
+    @XmlElement(name = "CalculationPercent")
+    protected PercentType calculationPercent;
+    @XmlElement(name = "BasisAmount")
+    protected AmountType basisAmount;
+    @XmlElement(name = "BasisQuantity")
+    protected QuantityType basisQuantity;
+    @XmlElement(name = "ActualAmount")
+    protected List<AmountType> actualAmount;
+    @XmlElement(name = "ReasonCode")
+    protected AllowanceChargeReasonCodeType reasonCode;
+    @XmlElement(name = "Reason")
+    protected TextType reason;
+    @XmlElement(name = "CategoryTradeTax")
+    protected List<TradeTaxType> categoryTradeTax;
+
+    /**
+     * Ruft den Wert der chargeIndicator-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IndicatorType }
+     *     
+     */
+    public IndicatorType getChargeIndicator() {
+        return chargeIndicator;
+    }
+
+    /**
+     * Legt den Wert der chargeIndicator-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IndicatorType }
+     *     
+     */
+    public void setChargeIndicator(IndicatorType value) {
+        this.chargeIndicator = value;
+    }
+
+    /**
+     * Ruft den Wert der sequenceNumeric-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link NumericType }
+     *     
+     */
+    public NumericType getSequenceNumeric() {
+        return sequenceNumeric;
+    }
+
+    /**
+     * Legt den Wert der sequenceNumeric-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link NumericType }
+     *     
+     */
+    public void setSequenceNumeric(NumericType value) {
+        this.sequenceNumeric = value;
+    }
+
+    /**
+     * Ruft den Wert der calculationPercent-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PercentType }
+     *     
+     */
+    public PercentType getCalculationPercent() {
+        return calculationPercent;
+    }
+
+    /**
+     * Legt den Wert der calculationPercent-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PercentType }
+     *     
+     */
+    public void setCalculationPercent(PercentType value) {
+        this.calculationPercent = value;
+    }
+
+    /**
+     * Ruft den Wert der basisAmount-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AmountType }
+     *     
+     */
+    public AmountType getBasisAmount() {
+        return basisAmount;
+    }
+
+    /**
+     * Legt den Wert der basisAmount-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AmountType }
+     *     
+     */
+    public void setBasisAmount(AmountType value) {
+        this.basisAmount = value;
+    }
+
+    /**
+     * Ruft den Wert der basisQuantity-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QuantityType }
+     *     
+     */
+    public QuantityType getBasisQuantity() {
+        return basisQuantity;
+    }
+
+    /**
+     * Legt den Wert der basisQuantity-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QuantityType }
+     *     
+     */
+    public void setBasisQuantity(QuantityType value) {
+        this.basisQuantity = value;
+    }
+
+    /**
+     * Gets the value of the actualAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the actualAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getActualAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getActualAmount() {
+        if (actualAmount == null) {
+            actualAmount = new ArrayList<AmountType>();
+        }
+        return this.actualAmount;
+    }
+
+    /**
+     * Ruft den Wert der reasonCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AllowanceChargeReasonCodeType }
+     *     
+     */
+    public AllowanceChargeReasonCodeType getReasonCode() {
+        return reasonCode;
+    }
+
+    /**
+     * Legt den Wert der reasonCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AllowanceChargeReasonCodeType }
+     *     
+     */
+    public void setReasonCode(AllowanceChargeReasonCodeType value) {
+        this.reasonCode = value;
+    }
+
+    /**
+     * Ruft den Wert der reason-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getReason() {
+        return reason;
+    }
+
+    /**
+     * Legt den Wert der reason-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setReason(TextType value) {
+        this.reason = value;
+    }
+
+    /**
+     * Gets the value of the categoryTradeTax property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the categoryTradeTax property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getCategoryTradeTax().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeTaxType }
+     * 
+     * 
+     */
+    public List<TradeTaxType> getCategoryTradeTax() {
+        if (categoryTradeTax == null) {
+            categoryTradeTax = new ArrayList<TradeTaxType>();
+        }
+        return this.categoryTradeTax;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeContactType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeContactType.java
@@ -1,0 +1,193 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeContactType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeContactType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="PersonName" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="DepartmentName" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="TelephoneUniversalCommunication" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}UniversalCommunicationType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="FaxUniversalCommunication" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}UniversalCommunicationType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="EmailURIUniversalCommunication" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}UniversalCommunicationType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeContactType", propOrder = {
+    "personName",
+    "departmentName",
+    "telephoneUniversalCommunication",
+    "faxUniversalCommunication",
+    "emailURIUniversalCommunication"
+})
+public class TradeContactType {
+
+    @XmlElement(name = "PersonName")
+    protected TextType personName;
+    @XmlElement(name = "DepartmentName")
+    protected TextType departmentName;
+    @XmlElement(name = "TelephoneUniversalCommunication")
+    protected List<UniversalCommunicationType> telephoneUniversalCommunication;
+    @XmlElement(name = "FaxUniversalCommunication")
+    protected List<UniversalCommunicationType> faxUniversalCommunication;
+    @XmlElement(name = "EmailURIUniversalCommunication")
+    protected UniversalCommunicationType emailURIUniversalCommunication;
+
+    /**
+     * Ruft den Wert der personName-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getPersonName() {
+        return personName;
+    }
+
+    /**
+     * Legt den Wert der personName-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setPersonName(TextType value) {
+        this.personName = value;
+    }
+
+    /**
+     * Ruft den Wert der departmentName-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getDepartmentName() {
+        return departmentName;
+    }
+
+    /**
+     * Legt den Wert der departmentName-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setDepartmentName(TextType value) {
+        this.departmentName = value;
+    }
+
+    /**
+     * Gets the value of the telephoneUniversalCommunication property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the telephoneUniversalCommunication property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getTelephoneUniversalCommunication().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link UniversalCommunicationType }
+     * 
+     * 
+     */
+    public List<UniversalCommunicationType> getTelephoneUniversalCommunication() {
+        if (telephoneUniversalCommunication == null) {
+            telephoneUniversalCommunication = new ArrayList<UniversalCommunicationType>();
+        }
+        return this.telephoneUniversalCommunication;
+    }
+
+    /**
+     * Gets the value of the faxUniversalCommunication property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the faxUniversalCommunication property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getFaxUniversalCommunication().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link UniversalCommunicationType }
+     * 
+     * 
+     */
+    public List<UniversalCommunicationType> getFaxUniversalCommunication() {
+        if (faxUniversalCommunication == null) {
+            faxUniversalCommunication = new ArrayList<UniversalCommunicationType>();
+        }
+        return this.faxUniversalCommunication;
+    }
+
+    /**
+     * Ruft den Wert der emailURIUniversalCommunication-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link UniversalCommunicationType }
+     *     
+     */
+    public UniversalCommunicationType getEmailURIUniversalCommunication() {
+        return emailURIUniversalCommunication;
+    }
+
+    /**
+     * Legt den Wert der emailURIUniversalCommunication-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link UniversalCommunicationType }
+     *     
+     */
+    public void setEmailURIUniversalCommunication(UniversalCommunicationType value) {
+        this.emailURIUniversalCommunication = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeCountryType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeCountryType.java
@@ -1,0 +1,76 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeCountryType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeCountryType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}CountryIDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeCountryType", propOrder = {
+    "id"
+})
+public class TradeCountryType {
+
+    @XmlElement(name = "ID")
+    protected List<CountryIDType> id;
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the id property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link CountryIDType }
+     * 
+     * 
+     */
+    public List<CountryIDType> getID() {
+        if (id == null) {
+            id = new ArrayList<CountryIDType>();
+        }
+        return this.id;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeDeliveryTermsType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeDeliveryTermsType.java
@@ -1,0 +1,69 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeDeliveryTermsType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeDeliveryTermsType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="DeliveryTypeCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}DeliveryTermsCodeType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeDeliveryTermsType", propOrder = {
+    "deliveryTypeCode"
+})
+public class TradeDeliveryTermsType {
+
+    @XmlElement(name = "DeliveryTypeCode")
+    protected DeliveryTermsCodeType deliveryTypeCode;
+
+    /**
+     * Ruft den Wert der deliveryTypeCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DeliveryTermsCodeType }
+     *     
+     */
+    public DeliveryTermsCodeType getDeliveryTypeCode() {
+        return deliveryTypeCode;
+    }
+
+    /**
+     * Legt den Wert der deliveryTypeCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DeliveryTermsCodeType }
+     *     
+     */
+    public void setDeliveryTypeCode(DeliveryTermsCodeType value) {
+        this.deliveryTypeCode = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePartyType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePartyType.java
@@ -1,0 +1,231 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradePartyType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradePartyType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="GlobalID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="Name" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="DefinedTradeContact" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeContactType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="PostalTradeAddress" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeAddressType" minOccurs="0"/&gt;
+ *         &lt;element name="SpecifiedTaxRegistration" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TaxRegistrationType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradePartyType", propOrder = {
+    "id",
+    "globalID",
+    "name",
+    "definedTradeContact",
+    "postalTradeAddress",
+    "specifiedTaxRegistration"
+})
+public class TradePartyType {
+
+    @XmlElement(name = "ID")
+    protected List<IDType> id;
+    @XmlElement(name = "GlobalID")
+    protected List<IDType> globalID;
+    @XmlElement(name = "Name")
+    protected TextType name;
+    @XmlElement(name = "DefinedTradeContact")
+    protected List<TradeContactType> definedTradeContact;
+    @XmlElement(name = "PostalTradeAddress")
+    protected TradeAddressType postalTradeAddress;
+    @XmlElement(name = "SpecifiedTaxRegistration")
+    protected List<TaxRegistrationType> specifiedTaxRegistration;
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the id property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link IDType }
+     * 
+     * 
+     */
+    public List<IDType> getID() {
+        if (id == null) {
+            id = new ArrayList<IDType>();
+        }
+        return this.id;
+    }
+
+    /**
+     * Gets the value of the globalID property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the globalID property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getGlobalID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link IDType }
+     * 
+     * 
+     */
+    public List<IDType> getGlobalID() {
+        if (globalID == null) {
+            globalID = new ArrayList<IDType>();
+        }
+        return this.globalID;
+    }
+
+    /**
+     * Ruft den Wert der name-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getName() {
+        return name;
+    }
+
+    /**
+     * Legt den Wert der name-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setName(TextType value) {
+        this.name = value;
+    }
+
+    /**
+     * Gets the value of the definedTradeContact property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the definedTradeContact property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDefinedTradeContact().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeContactType }
+     * 
+     * 
+     */
+    public List<TradeContactType> getDefinedTradeContact() {
+        if (definedTradeContact == null) {
+            definedTradeContact = new ArrayList<TradeContactType>();
+        }
+        return this.definedTradeContact;
+    }
+
+    /**
+     * Ruft den Wert der postalTradeAddress-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TradeAddressType }
+     *     
+     */
+    public TradeAddressType getPostalTradeAddress() {
+        return postalTradeAddress;
+    }
+
+    /**
+     * Legt den Wert der postalTradeAddress-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TradeAddressType }
+     *     
+     */
+    public void setPostalTradeAddress(TradeAddressType value) {
+        this.postalTradeAddress = value;
+    }
+
+    /**
+     * Gets the value of the specifiedTaxRegistration property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the specifiedTaxRegistration property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getSpecifiedTaxRegistration().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TaxRegistrationType }
+     * 
+     * 
+     */
+    public List<TaxRegistrationType> getSpecifiedTaxRegistration() {
+        if (specifiedTaxRegistration == null) {
+            specifiedTaxRegistration = new ArrayList<TaxRegistrationType>();
+        }
+        return this.specifiedTaxRegistration;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePaymentDiscountTermsType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePaymentDiscountTermsType.java
@@ -1,0 +1,193 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradePaymentDiscountTermsType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradePaymentDiscountTermsType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="BasisDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" minOccurs="0"/&gt;
+ *         &lt;element name="BasisPeriodMeasure" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}MeasureType" minOccurs="0"/&gt;
+ *         &lt;element name="BasisAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="CalculationPercent" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}PercentType" minOccurs="0"/&gt;
+ *         &lt;element name="ActualDiscountAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradePaymentDiscountTermsType", propOrder = {
+    "basisDateTime",
+    "basisPeriodMeasure",
+    "basisAmount",
+    "calculationPercent",
+    "actualDiscountAmount"
+})
+public class TradePaymentDiscountTermsType {
+
+    @XmlElement(name = "BasisDateTime")
+    protected DateTimeType basisDateTime;
+    @XmlElement(name = "BasisPeriodMeasure")
+    protected MeasureType basisPeriodMeasure;
+    @XmlElement(name = "BasisAmount")
+    protected List<AmountType> basisAmount;
+    @XmlElement(name = "CalculationPercent")
+    protected PercentType calculationPercent;
+    @XmlElement(name = "ActualDiscountAmount")
+    protected List<AmountType> actualDiscountAmount;
+
+    /**
+     * Ruft den Wert der basisDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public DateTimeType getBasisDateTime() {
+        return basisDateTime;
+    }
+
+    /**
+     * Legt den Wert der basisDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public void setBasisDateTime(DateTimeType value) {
+        this.basisDateTime = value;
+    }
+
+    /**
+     * Ruft den Wert der basisPeriodMeasure-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link MeasureType }
+     *     
+     */
+    public MeasureType getBasisPeriodMeasure() {
+        return basisPeriodMeasure;
+    }
+
+    /**
+     * Legt den Wert der basisPeriodMeasure-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link MeasureType }
+     *     
+     */
+    public void setBasisPeriodMeasure(MeasureType value) {
+        this.basisPeriodMeasure = value;
+    }
+
+    /**
+     * Gets the value of the basisAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the basisAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getBasisAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getBasisAmount() {
+        if (basisAmount == null) {
+            basisAmount = new ArrayList<AmountType>();
+        }
+        return this.basisAmount;
+    }
+
+    /**
+     * Ruft den Wert der calculationPercent-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PercentType }
+     *     
+     */
+    public PercentType getCalculationPercent() {
+        return calculationPercent;
+    }
+
+    /**
+     * Legt den Wert der calculationPercent-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PercentType }
+     *     
+     */
+    public void setCalculationPercent(PercentType value) {
+        this.calculationPercent = value;
+    }
+
+    /**
+     * Gets the value of the actualDiscountAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the actualDiscountAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getActualDiscountAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getActualDiscountAmount() {
+        if (actualDiscountAmount == null) {
+            actualDiscountAmount = new ArrayList<AmountType>();
+        }
+        return this.actualDiscountAmount;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePaymentPenaltyTermsType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePaymentPenaltyTermsType.java
@@ -1,0 +1,193 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradePaymentPenaltyTermsType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradePaymentPenaltyTermsType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="BasisDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" minOccurs="0"/&gt;
+ *         &lt;element name="BasisPeriodMeasure" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}MeasureType" minOccurs="0"/&gt;
+ *         &lt;element name="BasisAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="CalculationPercent" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}PercentType" minOccurs="0"/&gt;
+ *         &lt;element name="ActualPenaltyAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradePaymentPenaltyTermsType", propOrder = {
+    "basisDateTime",
+    "basisPeriodMeasure",
+    "basisAmount",
+    "calculationPercent",
+    "actualPenaltyAmount"
+})
+public class TradePaymentPenaltyTermsType {
+
+    @XmlElement(name = "BasisDateTime")
+    protected DateTimeType basisDateTime;
+    @XmlElement(name = "BasisPeriodMeasure")
+    protected MeasureType basisPeriodMeasure;
+    @XmlElement(name = "BasisAmount")
+    protected List<AmountType> basisAmount;
+    @XmlElement(name = "CalculationPercent")
+    protected PercentType calculationPercent;
+    @XmlElement(name = "ActualPenaltyAmount")
+    protected List<AmountType> actualPenaltyAmount;
+
+    /**
+     * Ruft den Wert der basisDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public DateTimeType getBasisDateTime() {
+        return basisDateTime;
+    }
+
+    /**
+     * Legt den Wert der basisDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public void setBasisDateTime(DateTimeType value) {
+        this.basisDateTime = value;
+    }
+
+    /**
+     * Ruft den Wert der basisPeriodMeasure-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link MeasureType }
+     *     
+     */
+    public MeasureType getBasisPeriodMeasure() {
+        return basisPeriodMeasure;
+    }
+
+    /**
+     * Legt den Wert der basisPeriodMeasure-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link MeasureType }
+     *     
+     */
+    public void setBasisPeriodMeasure(MeasureType value) {
+        this.basisPeriodMeasure = value;
+    }
+
+    /**
+     * Gets the value of the basisAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the basisAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getBasisAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getBasisAmount() {
+        if (basisAmount == null) {
+            basisAmount = new ArrayList<AmountType>();
+        }
+        return this.basisAmount;
+    }
+
+    /**
+     * Ruft den Wert der calculationPercent-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PercentType }
+     *     
+     */
+    public PercentType getCalculationPercent() {
+        return calculationPercent;
+    }
+
+    /**
+     * Legt den Wert der calculationPercent-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PercentType }
+     *     
+     */
+    public void setCalculationPercent(PercentType value) {
+        this.calculationPercent = value;
+    }
+
+    /**
+     * Gets the value of the actualPenaltyAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the actualPenaltyAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getActualPenaltyAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getActualPenaltyAmount() {
+        if (actualPenaltyAmount == null) {
+            actualPenaltyAmount = new ArrayList<AmountType>();
+        }
+        return this.actualPenaltyAmount;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePaymentTermsType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePaymentTermsType.java
@@ -1,0 +1,203 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradePaymentTermsType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradePaymentTermsType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="Description" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="DueDateDateTime" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}DateTimeType" minOccurs="0"/&gt;
+ *         &lt;element name="PartialPaymentAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicableTradePaymentPenaltyTerms" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePaymentPenaltyTermsType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicableTradePaymentDiscountTerms" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradePaymentDiscountTermsType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradePaymentTermsType", propOrder = {
+    "description",
+    "dueDateDateTime",
+    "partialPaymentAmount",
+    "applicableTradePaymentPenaltyTerms",
+    "applicableTradePaymentDiscountTerms"
+})
+public class TradePaymentTermsType {
+
+    @XmlElement(name = "Description")
+    protected List<TextType> description;
+    @XmlElement(name = "DueDateDateTime")
+    protected DateTimeType dueDateDateTime;
+    @XmlElement(name = "PartialPaymentAmount")
+    protected List<AmountType> partialPaymentAmount;
+    @XmlElement(name = "ApplicableTradePaymentPenaltyTerms")
+    protected List<TradePaymentPenaltyTermsType> applicableTradePaymentPenaltyTerms;
+    @XmlElement(name = "ApplicableTradePaymentDiscountTerms")
+    protected List<TradePaymentDiscountTermsType> applicableTradePaymentDiscountTerms;
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the description property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDescription().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getDescription() {
+        if (description == null) {
+            description = new ArrayList<TextType>();
+        }
+        return this.description;
+    }
+
+    /**
+     * Ruft den Wert der dueDateDateTime-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public DateTimeType getDueDateDateTime() {
+        return dueDateDateTime;
+    }
+
+    /**
+     * Legt den Wert der dueDateDateTime-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DateTimeType }
+     *     
+     */
+    public void setDueDateDateTime(DateTimeType value) {
+        this.dueDateDateTime = value;
+    }
+
+    /**
+     * Gets the value of the partialPaymentAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the partialPaymentAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getPartialPaymentAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getPartialPaymentAmount() {
+        if (partialPaymentAmount == null) {
+            partialPaymentAmount = new ArrayList<AmountType>();
+        }
+        return this.partialPaymentAmount;
+    }
+
+    /**
+     * Gets the value of the applicableTradePaymentPenaltyTerms property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the applicableTradePaymentPenaltyTerms property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getApplicableTradePaymentPenaltyTerms().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradePaymentPenaltyTermsType }
+     * 
+     * 
+     */
+    public List<TradePaymentPenaltyTermsType> getApplicableTradePaymentPenaltyTerms() {
+        if (applicableTradePaymentPenaltyTerms == null) {
+            applicableTradePaymentPenaltyTerms = new ArrayList<TradePaymentPenaltyTermsType>();
+        }
+        return this.applicableTradePaymentPenaltyTerms;
+    }
+
+    /**
+     * Gets the value of the applicableTradePaymentDiscountTerms property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the applicableTradePaymentDiscountTerms property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getApplicableTradePaymentDiscountTerms().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradePaymentDiscountTermsType }
+     * 
+     * 
+     */
+    public List<TradePaymentDiscountTermsType> getApplicableTradePaymentDiscountTerms() {
+        if (applicableTradePaymentDiscountTerms == null) {
+            applicableTradePaymentDiscountTerms = new ArrayList<TradePaymentDiscountTermsType>();
+        }
+        return this.applicableTradePaymentDiscountTerms;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePriceType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradePriceType.java
@@ -1,0 +1,137 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradePriceType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradePriceType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="ChargeAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="BasisQuantity" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}QuantityType" minOccurs="0"/&gt;
+ *         &lt;element name="AppliedTradeAllowanceCharge" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeAllowanceChargeType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradePriceType", propOrder = {
+    "chargeAmount",
+    "basisQuantity",
+    "appliedTradeAllowanceCharge"
+})
+public class TradePriceType {
+
+    @XmlElement(name = "ChargeAmount")
+    protected List<AmountType> chargeAmount;
+    @XmlElement(name = "BasisQuantity")
+    protected QuantityType basisQuantity;
+    @XmlElement(name = "AppliedTradeAllowanceCharge")
+    protected List<TradeAllowanceChargeType> appliedTradeAllowanceCharge;
+
+    /**
+     * Gets the value of the chargeAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the chargeAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getChargeAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getChargeAmount() {
+        if (chargeAmount == null) {
+            chargeAmount = new ArrayList<AmountType>();
+        }
+        return this.chargeAmount;
+    }
+
+    /**
+     * Ruft den Wert der basisQuantity-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QuantityType }
+     *     
+     */
+    public QuantityType getBasisQuantity() {
+        return basisQuantity;
+    }
+
+    /**
+     * Legt den Wert der basisQuantity-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QuantityType }
+     *     
+     */
+    public void setBasisQuantity(QuantityType value) {
+        this.basisQuantity = value;
+    }
+
+    /**
+     * Gets the value of the appliedTradeAllowanceCharge property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the appliedTradeAllowanceCharge property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getAppliedTradeAllowanceCharge().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeAllowanceChargeType }
+     * 
+     * 
+     */
+    public List<TradeAllowanceChargeType> getAppliedTradeAllowanceCharge() {
+        if (appliedTradeAllowanceCharge == null) {
+            appliedTradeAllowanceCharge = new ArrayList<TradeAllowanceChargeType>();
+        }
+        return this.appliedTradeAllowanceCharge;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeProductType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeProductType.java
@@ -1,0 +1,330 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeProductType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeProductType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="GlobalID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="SellerAssignedID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="BuyerAssignedID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="Name" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="Description" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicableProductCharacteristic" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ProductCharacteristicType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="DesignatedProductClassification" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ProductClassificationType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="OriginTradeCountry" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}TradeCountryType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="IncludedReferencedProduct" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}ReferencedProductType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeProductType", propOrder = {
+    "globalID",
+    "sellerAssignedID",
+    "buyerAssignedID",
+    "name",
+    "description",
+    "applicableProductCharacteristic",
+    "designatedProductClassification",
+    "originTradeCountry",
+    "includedReferencedProduct"
+})
+public class TradeProductType {
+
+    @XmlElement(name = "GlobalID")
+    protected List<IDType> globalID;
+    @XmlElement(name = "SellerAssignedID")
+    protected IDType sellerAssignedID;
+    @XmlElement(name = "BuyerAssignedID")
+    protected IDType buyerAssignedID;
+    @XmlElement(name = "Name")
+    protected List<TextType> name;
+    @XmlElement(name = "Description")
+    protected List<TextType> description;
+    @XmlElement(name = "ApplicableProductCharacteristic")
+    protected List<ProductCharacteristicType> applicableProductCharacteristic;
+    @XmlElement(name = "DesignatedProductClassification")
+    protected List<ProductClassificationType> designatedProductClassification;
+    @XmlElement(name = "OriginTradeCountry")
+    protected List<TradeCountryType> originTradeCountry;
+    @XmlElement(name = "IncludedReferencedProduct")
+    protected List<ReferencedProductType> includedReferencedProduct;
+
+    /**
+     * Gets the value of the globalID property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the globalID property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getGlobalID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link IDType }
+     * 
+     * 
+     */
+    public List<IDType> getGlobalID() {
+        if (globalID == null) {
+            globalID = new ArrayList<IDType>();
+        }
+        return this.globalID;
+    }
+
+    /**
+     * Ruft den Wert der sellerAssignedID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getSellerAssignedID() {
+        return sellerAssignedID;
+    }
+
+    /**
+     * Legt den Wert der sellerAssignedID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setSellerAssignedID(IDType value) {
+        this.sellerAssignedID = value;
+    }
+
+    /**
+     * Ruft den Wert der buyerAssignedID-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getBuyerAssignedID() {
+        return buyerAssignedID;
+    }
+
+    /**
+     * Legt den Wert der buyerAssignedID-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setBuyerAssignedID(IDType value) {
+        this.buyerAssignedID = value;
+    }
+
+    /**
+     * Gets the value of the name property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the name property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getName().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getName() {
+        if (name == null) {
+            name = new ArrayList<TextType>();
+        }
+        return this.name;
+    }
+
+    /**
+     * Gets the value of the description property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the description property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDescription().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getDescription() {
+        if (description == null) {
+            description = new ArrayList<TextType>();
+        }
+        return this.description;
+    }
+
+    /**
+     * Gets the value of the applicableProductCharacteristic property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the applicableProductCharacteristic property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getApplicableProductCharacteristic().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ProductCharacteristicType }
+     * 
+     * 
+     */
+    public List<ProductCharacteristicType> getApplicableProductCharacteristic() {
+        if (applicableProductCharacteristic == null) {
+            applicableProductCharacteristic = new ArrayList<ProductCharacteristicType>();
+        }
+        return this.applicableProductCharacteristic;
+    }
+
+    /**
+     * Gets the value of the designatedProductClassification property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the designatedProductClassification property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDesignatedProductClassification().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ProductClassificationType }
+     * 
+     * 
+     */
+    public List<ProductClassificationType> getDesignatedProductClassification() {
+        if (designatedProductClassification == null) {
+            designatedProductClassification = new ArrayList<ProductClassificationType>();
+        }
+        return this.designatedProductClassification;
+    }
+
+    /**
+     * Gets the value of the originTradeCountry property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the originTradeCountry property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getOriginTradeCountry().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TradeCountryType }
+     * 
+     * 
+     */
+    public List<TradeCountryType> getOriginTradeCountry() {
+        if (originTradeCountry == null) {
+            originTradeCountry = new ArrayList<TradeCountryType>();
+        }
+        return this.originTradeCountry;
+    }
+
+    /**
+     * Gets the value of the includedReferencedProduct property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the includedReferencedProduct property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getIncludedReferencedProduct().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link ReferencedProductType }
+     * 
+     * 
+     */
+    public List<ReferencedProductType> getIncludedReferencedProduct() {
+        if (includedReferencedProduct == null) {
+            includedReferencedProduct = new ArrayList<ReferencedProductType>();
+        }
+        return this.includedReferencedProduct;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeSettlementMonetarySummationType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeSettlementMonetarySummationType.java
@@ -1,0 +1,340 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeSettlementMonetarySummationType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeSettlementMonetarySummationType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="LineTotalAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ChargeTotalAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="AllowanceTotalAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="TaxBasisTotalAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="TaxTotalAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="GrandTotalAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="TotalPrepaidAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="TotalAllowanceChargeAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="DuePayableAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeSettlementMonetarySummationType", propOrder = {
+    "lineTotalAmount",
+    "chargeTotalAmount",
+    "allowanceTotalAmount",
+    "taxBasisTotalAmount",
+    "taxTotalAmount",
+    "grandTotalAmount",
+    "totalPrepaidAmount",
+    "totalAllowanceChargeAmount",
+    "duePayableAmount"
+})
+public class TradeSettlementMonetarySummationType {
+
+    @XmlElement(name = "LineTotalAmount")
+    protected List<AmountType> lineTotalAmount;
+    @XmlElement(name = "ChargeTotalAmount")
+    protected List<AmountType> chargeTotalAmount;
+    @XmlElement(name = "AllowanceTotalAmount")
+    protected List<AmountType> allowanceTotalAmount;
+    @XmlElement(name = "TaxBasisTotalAmount")
+    protected List<AmountType> taxBasisTotalAmount;
+    @XmlElement(name = "TaxTotalAmount")
+    protected List<AmountType> taxTotalAmount;
+    @XmlElement(name = "GrandTotalAmount")
+    protected List<AmountType> grandTotalAmount;
+    @XmlElement(name = "TotalPrepaidAmount")
+    protected List<AmountType> totalPrepaidAmount;
+    @XmlElement(name = "TotalAllowanceChargeAmount")
+    protected List<AmountType> totalAllowanceChargeAmount;
+    @XmlElement(name = "DuePayableAmount")
+    protected List<AmountType> duePayableAmount;
+
+    /**
+     * Gets the value of the lineTotalAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the lineTotalAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getLineTotalAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getLineTotalAmount() {
+        if (lineTotalAmount == null) {
+            lineTotalAmount = new ArrayList<AmountType>();
+        }
+        return this.lineTotalAmount;
+    }
+
+    /**
+     * Gets the value of the chargeTotalAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the chargeTotalAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getChargeTotalAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getChargeTotalAmount() {
+        if (chargeTotalAmount == null) {
+            chargeTotalAmount = new ArrayList<AmountType>();
+        }
+        return this.chargeTotalAmount;
+    }
+
+    /**
+     * Gets the value of the allowanceTotalAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the allowanceTotalAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getAllowanceTotalAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getAllowanceTotalAmount() {
+        if (allowanceTotalAmount == null) {
+            allowanceTotalAmount = new ArrayList<AmountType>();
+        }
+        return this.allowanceTotalAmount;
+    }
+
+    /**
+     * Gets the value of the taxBasisTotalAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the taxBasisTotalAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getTaxBasisTotalAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getTaxBasisTotalAmount() {
+        if (taxBasisTotalAmount == null) {
+            taxBasisTotalAmount = new ArrayList<AmountType>();
+        }
+        return this.taxBasisTotalAmount;
+    }
+
+    /**
+     * Gets the value of the taxTotalAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the taxTotalAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getTaxTotalAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getTaxTotalAmount() {
+        if (taxTotalAmount == null) {
+            taxTotalAmount = new ArrayList<AmountType>();
+        }
+        return this.taxTotalAmount;
+    }
+
+    /**
+     * Gets the value of the grandTotalAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the grandTotalAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getGrandTotalAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getGrandTotalAmount() {
+        if (grandTotalAmount == null) {
+            grandTotalAmount = new ArrayList<AmountType>();
+        }
+        return this.grandTotalAmount;
+    }
+
+    /**
+     * Gets the value of the totalPrepaidAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the totalPrepaidAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getTotalPrepaidAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getTotalPrepaidAmount() {
+        if (totalPrepaidAmount == null) {
+            totalPrepaidAmount = new ArrayList<AmountType>();
+        }
+        return this.totalPrepaidAmount;
+    }
+
+    /**
+     * Gets the value of the totalAllowanceChargeAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the totalAllowanceChargeAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getTotalAllowanceChargeAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getTotalAllowanceChargeAmount() {
+        if (totalAllowanceChargeAmount == null) {
+            totalAllowanceChargeAmount = new ArrayList<AmountType>();
+        }
+        return this.totalAllowanceChargeAmount;
+    }
+
+    /**
+     * Gets the value of the duePayableAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the duePayableAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getDuePayableAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getDuePayableAmount() {
+        if (duePayableAmount == null) {
+            duePayableAmount = new ArrayList<AmountType>();
+        }
+        return this.duePayableAmount;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeSettlementPaymentMeansType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeSettlementPaymentMeansType.java
@@ -1,0 +1,249 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeSettlementPaymentMeansType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeSettlementPaymentMeansType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="TypeCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}PaymentMeansCodeType" minOccurs="0"/&gt;
+ *         &lt;element name="Information" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="ID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="PayerPartyDebtorFinancialAccount" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}DebtorFinancialAccountType" minOccurs="0"/&gt;
+ *         &lt;element name="PayeePartyCreditorFinancialAccount" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}CreditorFinancialAccountType" minOccurs="0"/&gt;
+ *         &lt;element name="PayerSpecifiedDebtorFinancialInstitution" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}DebtorFinancialInstitutionType" minOccurs="0"/&gt;
+ *         &lt;element name="PayeeSpecifiedCreditorFinancialInstitution" type="{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12}CreditorFinancialInstitutionType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeSettlementPaymentMeansType", propOrder = {
+    "typeCode",
+    "information",
+    "id",
+    "payerPartyDebtorFinancialAccount",
+    "payeePartyCreditorFinancialAccount",
+    "payerSpecifiedDebtorFinancialInstitution",
+    "payeeSpecifiedCreditorFinancialInstitution"
+})
+public class TradeSettlementPaymentMeansType {
+
+    @XmlElement(name = "TypeCode")
+    protected PaymentMeansCodeType typeCode;
+    @XmlElement(name = "Information")
+    protected List<TextType> information;
+    @XmlElement(name = "ID")
+    protected List<IDType> id;
+    @XmlElement(name = "PayerPartyDebtorFinancialAccount")
+    protected DebtorFinancialAccountType payerPartyDebtorFinancialAccount;
+    @XmlElement(name = "PayeePartyCreditorFinancialAccount")
+    protected CreditorFinancialAccountType payeePartyCreditorFinancialAccount;
+    @XmlElement(name = "PayerSpecifiedDebtorFinancialInstitution")
+    protected DebtorFinancialInstitutionType payerSpecifiedDebtorFinancialInstitution;
+    @XmlElement(name = "PayeeSpecifiedCreditorFinancialInstitution")
+    protected CreditorFinancialInstitutionType payeeSpecifiedCreditorFinancialInstitution;
+
+    /**
+     * Ruft den Wert der typeCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PaymentMeansCodeType }
+     *     
+     */
+    public PaymentMeansCodeType getTypeCode() {
+        return typeCode;
+    }
+
+    /**
+     * Legt den Wert der typeCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PaymentMeansCodeType }
+     *     
+     */
+    public void setTypeCode(PaymentMeansCodeType value) {
+        this.typeCode = value;
+    }
+
+    /**
+     * Gets the value of the information property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the information property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getInformation().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TextType }
+     * 
+     * 
+     */
+    public List<TextType> getInformation() {
+        if (information == null) {
+            information = new ArrayList<TextType>();
+        }
+        return this.information;
+    }
+
+    /**
+     * Gets the value of the id property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the id property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getID().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link IDType }
+     * 
+     * 
+     */
+    public List<IDType> getID() {
+        if (id == null) {
+            id = new ArrayList<IDType>();
+        }
+        return this.id;
+    }
+
+    /**
+     * Ruft den Wert der payerPartyDebtorFinancialAccount-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DebtorFinancialAccountType }
+     *     
+     */
+    public DebtorFinancialAccountType getPayerPartyDebtorFinancialAccount() {
+        return payerPartyDebtorFinancialAccount;
+    }
+
+    /**
+     * Legt den Wert der payerPartyDebtorFinancialAccount-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DebtorFinancialAccountType }
+     *     
+     */
+    public void setPayerPartyDebtorFinancialAccount(DebtorFinancialAccountType value) {
+        this.payerPartyDebtorFinancialAccount = value;
+    }
+
+    /**
+     * Ruft den Wert der payeePartyCreditorFinancialAccount-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CreditorFinancialAccountType }
+     *     
+     */
+    public CreditorFinancialAccountType getPayeePartyCreditorFinancialAccount() {
+        return payeePartyCreditorFinancialAccount;
+    }
+
+    /**
+     * Legt den Wert der payeePartyCreditorFinancialAccount-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CreditorFinancialAccountType }
+     *     
+     */
+    public void setPayeePartyCreditorFinancialAccount(CreditorFinancialAccountType value) {
+        this.payeePartyCreditorFinancialAccount = value;
+    }
+
+    /**
+     * Ruft den Wert der payerSpecifiedDebtorFinancialInstitution-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link DebtorFinancialInstitutionType }
+     *     
+     */
+    public DebtorFinancialInstitutionType getPayerSpecifiedDebtorFinancialInstitution() {
+        return payerSpecifiedDebtorFinancialInstitution;
+    }
+
+    /**
+     * Legt den Wert der payerSpecifiedDebtorFinancialInstitution-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link DebtorFinancialInstitutionType }
+     *     
+     */
+    public void setPayerSpecifiedDebtorFinancialInstitution(DebtorFinancialInstitutionType value) {
+        this.payerSpecifiedDebtorFinancialInstitution = value;
+    }
+
+    /**
+     * Ruft den Wert der payeeSpecifiedCreditorFinancialInstitution-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CreditorFinancialInstitutionType }
+     *     
+     */
+    public CreditorFinancialInstitutionType getPayeeSpecifiedCreditorFinancialInstitution() {
+        return payeeSpecifiedCreditorFinancialInstitution;
+    }
+
+    /**
+     * Legt den Wert der payeeSpecifiedCreditorFinancialInstitution-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CreditorFinancialInstitutionType }
+     *     
+     */
+    public void setPayeeSpecifiedCreditorFinancialInstitution(CreditorFinancialInstitutionType value) {
+        this.payeeSpecifiedCreditorFinancialInstitution = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeTaxType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/TradeTaxType.java
@@ -1,0 +1,287 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r TradeTaxType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="TradeTaxType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="CalculatedAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="TypeCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}TaxTypeCodeType" minOccurs="0"/&gt;
+ *         &lt;element name="ExemptionReason" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *         &lt;element name="BasisAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="LineTotalBasisAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="AllowanceChargeBasisAmount" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}AmountType" maxOccurs="unbounded" minOccurs="0"/&gt;
+ *         &lt;element name="CategoryCode" type="{urn:un:unece:uncefact:data:standard:QualifiedDataType:12}TaxCategoryCodeType" minOccurs="0"/&gt;
+ *         &lt;element name="ApplicablePercent" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}PercentType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TradeTaxType", propOrder = {
+    "calculatedAmount",
+    "typeCode",
+    "exemptionReason",
+    "basisAmount",
+    "lineTotalBasisAmount",
+    "allowanceChargeBasisAmount",
+    "categoryCode",
+    "applicablePercent"
+})
+public class TradeTaxType {
+
+    @XmlElement(name = "CalculatedAmount")
+    protected List<AmountType> calculatedAmount;
+    @XmlElement(name = "TypeCode")
+    protected TaxTypeCodeType typeCode;
+    @XmlElement(name = "ExemptionReason")
+    protected TextType exemptionReason;
+    @XmlElement(name = "BasisAmount")
+    protected List<AmountType> basisAmount;
+    @XmlElement(name = "LineTotalBasisAmount")
+    protected List<AmountType> lineTotalBasisAmount;
+    @XmlElement(name = "AllowanceChargeBasisAmount")
+    protected List<AmountType> allowanceChargeBasisAmount;
+    @XmlElement(name = "CategoryCode")
+    protected TaxCategoryCodeType categoryCode;
+    @XmlElement(name = "ApplicablePercent")
+    protected PercentType applicablePercent;
+
+    /**
+     * Gets the value of the calculatedAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the calculatedAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getCalculatedAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getCalculatedAmount() {
+        if (calculatedAmount == null) {
+            calculatedAmount = new ArrayList<AmountType>();
+        }
+        return this.calculatedAmount;
+    }
+
+    /**
+     * Ruft den Wert der typeCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TaxTypeCodeType }
+     *     
+     */
+    public TaxTypeCodeType getTypeCode() {
+        return typeCode;
+    }
+
+    /**
+     * Legt den Wert der typeCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TaxTypeCodeType }
+     *     
+     */
+    public void setTypeCode(TaxTypeCodeType value) {
+        this.typeCode = value;
+    }
+
+    /**
+     * Ruft den Wert der exemptionReason-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getExemptionReason() {
+        return exemptionReason;
+    }
+
+    /**
+     * Legt den Wert der exemptionReason-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setExemptionReason(TextType value) {
+        this.exemptionReason = value;
+    }
+
+    /**
+     * Gets the value of the basisAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the basisAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getBasisAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getBasisAmount() {
+        if (basisAmount == null) {
+            basisAmount = new ArrayList<AmountType>();
+        }
+        return this.basisAmount;
+    }
+
+    /**
+     * Gets the value of the lineTotalBasisAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the lineTotalBasisAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getLineTotalBasisAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getLineTotalBasisAmount() {
+        if (lineTotalBasisAmount == null) {
+            lineTotalBasisAmount = new ArrayList<AmountType>();
+        }
+        return this.lineTotalBasisAmount;
+    }
+
+    /**
+     * Gets the value of the allowanceChargeBasisAmount property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the allowanceChargeBasisAmount property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getAllowanceChargeBasisAmount().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link AmountType }
+     * 
+     * 
+     */
+    public List<AmountType> getAllowanceChargeBasisAmount() {
+        if (allowanceChargeBasisAmount == null) {
+            allowanceChargeBasisAmount = new ArrayList<AmountType>();
+        }
+        return this.allowanceChargeBasisAmount;
+    }
+
+    /**
+     * Ruft den Wert der categoryCode-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TaxCategoryCodeType }
+     *     
+     */
+    public TaxCategoryCodeType getCategoryCode() {
+        return categoryCode;
+    }
+
+    /**
+     * Legt den Wert der categoryCode-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TaxCategoryCodeType }
+     *     
+     */
+    public void setCategoryCode(TaxCategoryCodeType value) {
+        this.categoryCode = value;
+    }
+
+    /**
+     * Ruft den Wert der applicablePercent-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link PercentType }
+     *     
+     */
+    public PercentType getApplicablePercent() {
+        return applicablePercent;
+    }
+
+    /**
+     * Legt den Wert der applicablePercent-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link PercentType }
+     *     
+     */
+    public void setApplicablePercent(PercentType value) {
+        this.applicablePercent = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/UniversalCommunicationType.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/UniversalCommunicationType.java
@@ -1,0 +1,97 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java-Klasse f�r UniversalCommunicationType complex type.
+ * 
+ * <p>Das folgende Schemafragment gibt den erwarteten Content an, der in dieser Klasse enthalten ist.
+ * 
+ * <pre>
+ * &lt;complexType name="UniversalCommunicationType"&gt;
+ *   &lt;complexContent&gt;
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType"&gt;
+ *       &lt;sequence&gt;
+ *         &lt;element name="URIID" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}IDType" minOccurs="0"/&gt;
+ *         &lt;element name="CompleteNumber" type="{urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15}TextType" minOccurs="0"/&gt;
+ *       &lt;/sequence&gt;
+ *     &lt;/restriction&gt;
+ *   &lt;/complexContent&gt;
+ * &lt;/complexType&gt;
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "UniversalCommunicationType", propOrder = {
+    "uriid",
+    "completeNumber"
+})
+public class UniversalCommunicationType {
+
+    @XmlElement(name = "URIID")
+    protected IDType uriid;
+    @XmlElement(name = "CompleteNumber")
+    protected TextType completeNumber;
+
+    /**
+     * Ruft den Wert der uriid-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link IDType }
+     *     
+     */
+    public IDType getURIID() {
+        return uriid;
+    }
+
+    /**
+     * Legt den Wert der uriid-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link IDType }
+     *     
+     */
+    public void setURIID(IDType value) {
+        this.uriid = value;
+    }
+
+    /**
+     * Ruft den Wert der completeNumber-Eigenschaft ab.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TextType }
+     *     
+     */
+    public TextType getCompleteNumber() {
+        return completeNumber;
+    }
+
+    /**
+     * Legt den Wert der completeNumber-Eigenschaft fest.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TextType }
+     *     
+     */
+    public void setCompleteNumber(TextType value) {
+        this.completeNumber = value;
+    }
+
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/package-info.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/model/package-info.java
@@ -1,0 +1,18 @@
+//
+// Diese Datei wurde mit der JavaTM Architecture for XML Binding(JAXB) Reference Implementation, v2.2.11 generiert 
+// Siehe <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
+// �nderungen an dieser Datei gehen bei einer Neukompilierung des Quellschemas verloren. 
+// Generiert: 2015.10.16 um 06:16:03 PM CEST 
+//
+
+@XmlSchema(namespace = "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12", 
+        xmlns = { 
+        @XmlNs(namespaceURI = "http://www.w3.org/2001/XMLSchema-instance", prefix = "xsi"),
+        @XmlNs(namespaceURI = "urn:ferd:CrossIndustryDocument:invoice:1p0", prefix = "rsm"),
+        @XmlNs(namespaceURI = "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12", prefix = "ram"),
+        @XmlNs(namespaceURI = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15", prefix = "udt"),
+        },
+        elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.mustangproject.ZUGFeRD.model;
+
+import javax.xml.bind.annotation.*;

--- a/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
+++ b/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
@@ -3,6 +3,7 @@ package org.mustangproject.ZUGFeRD;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -131,6 +132,22 @@ public class MustangReaderWriterEdgeTest extends TestCase implements IZUGFeRDExp
     allItems[2] = new Item(new BigDecimal("0.10"), new BigDecimal("200"), airProduct);
     return allItems;
   }
+
+    @Override
+    public String getInvoiceCurrency() {
+        return "EUR";
+    }
+
+    @Override
+    public String getOwnPaymentInfoText() {
+        return "Überweisung";
+    }
+
+    @Override
+    public String getPaymentTermDescription() {
+        SimpleDateFormat germanDateFormat = new SimpleDateFormat("dd.MM.yyyy");
+        return "Zahlbar ohne Abzug bis zum " + germanDateFormat.format(getDueDate());
+    }
 
   class Contact implements IZUGFeRDExportableContact
   {

--- a/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
+++ b/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
@@ -3,6 +3,7 @@ package org.mustangproject.ZUGFeRD;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -130,6 +131,22 @@ public class MustangReaderWriterTest extends TestCase implements IZUGFeRDExporta
     allItems[2] = new Item(new BigDecimal("0.10"), new BigDecimal("200"), airProduct);
     return allItems;
   }
+
+    @Override
+    public String getInvoiceCurrency() {
+        return "EUR";
+    }
+
+    @Override
+    public String getOwnPaymentInfoText() {
+        return "Überweisung";
+    }
+
+    @Override
+    public String getPaymentTermDescription() {
+        SimpleDateFormat germanDateFormat = new SimpleDateFormat("dd.MM.yyyy");
+        return "Zahlbar ohne Abzug bis zum " + germanDateFormat.format(getDueDate());
+    }
 
   class Contact implements IZUGFeRDExportableContact
   {


### PR DESCRIPTION
This change should make sure that we're always getting valid XML (no special character issues or something). However, this does not guarantee that the XML is a valid ZUGFeRD invoice.

- Generated JAXB Model classes with official ZUGFeRD Schema file (ZUGFeRD1p0.xsd)
- Exchanged String based XML generation in ZUGFeRDExporter with JAXB XML generation using the generated Model classes.
- Enhanced some model classes with constants from ZUGFeRD codelists. (E.g. DocumentCodeType.INVOICE, DocumentCodeType.CREDITNOTE)
- Enhanced interface IZUGFeRDExportableTransaction with methods getInvoiceCurrency, getOwnPaymentInfoText and getPaymentTermDescription to avoid hard-coded values.
- Enhanced test classes to implement the new interface methods
- Added maven dependency for org.glassfish.jaxb
- Increased version number to 1.3.0