### PR TITLE
Validation error fixes and support for allowances, charges and service charges

### DIFF
--- a/mustang/pom.xml
+++ b/mustang/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.rayman2200</groupId>
         <artifactId>mustang-sample-project</artifactId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.mustangproject.ZUGFeRD</groupId>

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
  * @author AlexanderSchmidt
  */
 public interface IZUGFeRDAllowanceCharge {
-    BigDecimal getAmount();
+    BigDecimal getTotalAmount();
     
     String getReason();
     

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 AlexanderSchmidt.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mustangproject.ZUGFeRD;
+
+import java.math.BigDecimal;
+
+/**
+ *
+ * @author AlexanderSchmidt
+ */
+public interface IZUGFeRDAllowanceCharge {
+    BigDecimal getAmount();
+    
+    String getReason();
+    
+    BigDecimal getTaxPercent();
+    
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
@@ -13,7 +13,8 @@ import java.math.BigDecimal;
 public interface IZUGFeRDExportableItem {
 
 	IZUGFeRDExportableProduct getProduct();
-
+        IZUGFeRDAllowanceCharge[] getItemAllowances();
+        IZUGFeRDAllowanceCharge[] getItemCharges();
 
 
 	/**

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
@@ -45,6 +45,10 @@ public interface IZUGFeRDExportableTransaction {
 	 * @return
 	 */
 	Date getDueDate();
+        
+        IZUGFeRDAllowanceCharge[] getZFAllowances();
+        IZUGFeRDAllowanceCharge[] getZFCharges();
+        IZUGFeRDAllowanceCharge[] getZFLogisticsServiceCharges();        
 
 	IZUGFeRDExportableItem[] getZFItems();
 

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
@@ -4,32 +4,36 @@ import java.math.BigDecimal;
 
 public class VATAmount {
 
-	public VATAmount(BigDecimal basis, BigDecimal calculated) {
-		super();
-		this.basis = basis;
-		this.calculated = calculated;
-	}
+    public VATAmount(BigDecimal basis, BigDecimal calculated) {
+        super();
+        this.basis = basis;
+        this.calculated = calculated;
+    }
 
-	BigDecimal basis, calculated;
+    BigDecimal basis, calculated;
 
-	public BigDecimal getBasis() {
-		return basis;
-	}
+    public BigDecimal getBasis() {
+        return basis;
+    }
 
-	public void setBasis(BigDecimal basis) {
-		this.basis = basis;
-	}
+    public void setBasis(BigDecimal basis) {
+        this.basis = basis;
+    }
 
-	public BigDecimal getCalculated() {
-		return calculated;
-	}
+    public BigDecimal getCalculated() {
+        return calculated;
+    }
 
-	public void setCalculated(BigDecimal calculated) {
-		this.calculated = calculated;
-	}
-	
-	public VATAmount add(VATAmount v) {
-		return new VATAmount(basis.add(v.getBasis()), calculated.add(v.getCalculated()));
-	}
+    public void setCalculated(BigDecimal calculated) {
+        this.calculated = calculated;
+    }
+
+    public VATAmount add(VATAmount v) {
+        return new VATAmount(basis.add(v.getBasis()), calculated.add(v.getCalculated()));
+    }
+
+    public VATAmount subtract(VATAmount v) {
+        return new VATAmount(basis.subtract(v.getBasis()), calculated.subtract(v.getCalculated()));
+    }
 
 }

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -476,6 +476,7 @@ public class ZUGFeRDExporter {
         tradeSettlement.getSpecifiedTradeSettlementPaymentMeans().add(this.getPaymentData());
         tradeSettlement.getApplicableTradeTax().addAll(this.getTradeTax());
         tradeSettlement.getSpecifiedTradePaymentTerms().addAll(this.getPaymentTerms());
+        tradeSettlement.getSpecifiedTradeAllowanceCharge().addAll(this.getHeaderAllowances());
         tradeSettlement.setSpecifiedTradeSettlementMonetarySummation(this.getMonetarySummation());
 
         return tradeSettlement;
@@ -545,6 +546,43 @@ public class ZUGFeRDExporter {
         return tradeTaxTypes;
     }
 
+    private Collection<TradeAllowanceChargeType> getHeaderAllowances() {
+        List<TradeAllowanceChargeType> headerAllowances = new ArrayList<TradeAllowanceChargeType>();
+
+        for (IZUGFeRDAllowanceCharge iAllowance : trans.getZFAllowances()) {
+            
+            TradeAllowanceChargeType allowance = xmlFactory.createTradeAllowanceChargeType();
+            
+            IndicatorType chargeIndicator = xmlFactory.createIndicatorType();
+            chargeIndicator.setIndicator(false);
+            allowance.setChargeIndicator(chargeIndicator);
+            
+            TextType reason = xmlFactory.createTextType();
+            reason.setValue(iAllowance.getReason());
+            allowance.setReason(reason);
+            
+            TradeTaxType tradeTax = xmlFactory.createTradeTaxType();
+            
+            PercentType vatPercent = xmlFactory.createPercentType();
+            vatPercent.setValue(iAllowance.getTaxPercent());
+            tradeTax.setApplicablePercent(vatPercent);
+            
+            TaxCategoryCodeType taxType = xmlFactory.createTaxCategoryCodeType();
+            taxType.setValue(TaxCategoryCodeType.STANDARDRATE);
+            tradeTax.setCategoryCode(taxType);
+            
+            TaxTypeCodeType taxCode = xmlFactory.createTaxTypeCodeType();
+            taxCode.setValue(TaxTypeCodeType.SALESTAX);
+            tradeTax.setTypeCode(taxCode);
+            
+            allowance.getCategoryTradeTax().add(tradeTax);
+            headerAllowances.add(allowance);
+            
+        }
+
+        return headerAllowances;
+    }
+
     private Collection<TradePaymentTermsType> getPaymentTerms() {
         List<TradePaymentTermsType> paymentTerms = new ArrayList<TradePaymentTermsType>();
 
@@ -564,7 +602,7 @@ public class ZUGFeRDExporter {
         paymentTerms.add(paymentTerm);
 
         return paymentTerms;
-    }
+    }    
 
     private TradeSettlementMonetarySummationType getMonetarySummation() {
         TradeSettlementMonetarySummationType monetarySummation = xmlFactory.createTradeSettlementMonetarySummationType();

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -326,6 +326,10 @@ public class ZUGFeRDExporter {
         documentCodeType.setValue(DocumentCodeType.INVOICE);
         document.setTypeCode(documentCodeType);
 
+        TextType name = xmlFactory.createTextType();
+        name.setValue("RECHNUNG");
+        document.getName().add(name);
+        
         if (trans.getOwnOrganisationFullPlaintextInfo() != null) {
             NoteType regularInfo = xmlFactory.createNoteType();
             CodeType regularInfoSubjectCode = xmlFactory.createCodeType();
@@ -653,6 +657,15 @@ public class ZUGFeRDExporter {
 
             SupplyChainTradeSettlementType tradeSettlement = xmlFactory.createSupplyChainTradeSettlementType();
             TradeTaxType tradeTax = xmlFactory.createTradeTaxType();
+            
+            TaxCategoryCodeType taxCategoryCode = xmlFactory.createTaxCategoryCodeType();
+            taxCategoryCode.setValue(TaxCategoryCodeType.STANDARDRATE);
+            tradeTax.setCategoryCode(taxCategoryCode);
+            
+            TaxTypeCodeType taxCode = xmlFactory.createTaxTypeCodeType();
+            taxCode.setValue(TaxTypeCodeType.SALESTAX);
+            tradeTax.setTypeCode(taxCode);
+            
             PercentType taxPercent = xmlFactory.createPercentType();
             taxPercent.setValue(vatFormat(currentItem.getProduct().getVATPercent()));
             tradeTax.setApplicablePercent(taxPercent);

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -476,7 +476,9 @@ public class ZUGFeRDExporter {
         tradeSettlement.getSpecifiedTradeSettlementPaymentMeans().add(this.getPaymentData());
         tradeSettlement.getApplicableTradeTax().addAll(this.getTradeTax());
         tradeSettlement.getSpecifiedTradePaymentTerms().addAll(this.getPaymentTerms());
-        tradeSettlement.getSpecifiedTradeAllowanceCharge().addAll(this.getHeaderAllowances());
+        if(trans.getZFAllowances() != null){
+            tradeSettlement.getSpecifiedTradeAllowanceCharge().addAll(this.getHeaderAllowances());
+        }
         tradeSettlement.setSpecifiedTradeSettlementMonetarySummation(this.getMonetarySummation());
 
         return tradeSettlement;

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -72,7 +72,7 @@ public class ZUGFeRDExporter {
         jaxbContext = JAXBContext.newInstance("org.mustangproject.ZUGFeRD.model");
         marshaller = jaxbContext.createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-        marshaller.setProperty("jaxb.encoding", "UTF-8");
+        marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
     }
 
     private class LineCalc {
@@ -749,7 +749,7 @@ public class ZUGFeRDExporter {
             // create a dummy file stream, this would probably normally be a
             // FileInputStream
 
-            byte[] zugferdRaw = getZugferdXMLForTransaction(trans).getBytes("UTF-8"); //$NON-NLS-1$
+            byte[] zugferdRaw = getZugferdXMLForTransaction(trans).getBytes(); //$NON-NLS-1$
 
             if ((zugferdRaw[0] == (byte) 0xEF) && (zugferdRaw[1] == (byte) 0xBB) && (zugferdRaw[2] == (byte) 0xBF)) {
                 // I don't like BOMs, lets remove it

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -630,7 +630,7 @@ public class ZUGFeRDExporter {
 
             AmountType grossChargeAmount = xmlFactory.createAmountType();
             grossChargeAmount.setCurrencyID(trans.getInvoiceCurrency());
-            grossChargeAmount.setValue(currencyFormat(currentItem.getPrice()));
+            grossChargeAmount.setValue(priceFormat(currentItem.getPrice()));
             grossTradePrice.getChargeAmount().add(grossChargeAmount);
             tradeAgreement.getGrossPriceProductTradePrice().add(grossTradePrice);
 
@@ -642,7 +642,7 @@ public class ZUGFeRDExporter {
 
             AmountType netChargeAmount = xmlFactory.createAmountType();
             netChargeAmount.setCurrencyID(trans.getInvoiceCurrency());
-            netChargeAmount.setValue(currencyFormat(currentItem.getPrice()));
+            netChargeAmount.setValue(priceFormat(currentItem.getPrice()));
             netTradePrice.getChargeAmount().add(netChargeAmount);
             tradeAgreement.getNetPriceProductTradePrice().add(netTradePrice);
 

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -87,12 +87,16 @@ public class ZUGFeRDExporter {
             BigDecimal totalAllowance = BigDecimal.ZERO;
             BigDecimal totalCharge = BigDecimal.ZERO;
             
-            for(IZUGFeRDAllowanceCharge itemAllowance : currentItem.getItemAllowances()){
-                totalAllowance = itemAllowance.getTotalAmount().add(totalAllowance);
+            if(currentItem.getItemAllowances() != null){
+                for(IZUGFeRDAllowanceCharge itemAllowance : currentItem.getItemAllowances()){
+                    totalAllowance = itemAllowance.getTotalAmount().add(totalAllowance);
+                }
             }
             
-            for(IZUGFeRDAllowanceCharge itemCharge : currentItem.getItemCharges()){
-                totalCharge = itemCharge.getTotalAmount().add(totalCharge);
+            if(currentItem.getItemCharges() != null){
+                for(IZUGFeRDAllowanceCharge itemCharge : currentItem.getItemCharges()){
+                    totalCharge = itemCharge.getTotalAmount().add(totalCharge);
+                }
             }
             
             BigDecimal multiplicator = currentItem.getProduct().getVATPercent().divide(new BigDecimal(100), 4, BigDecimal.ROUND_HALF_UP).add(BigDecimal.ONE);

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -103,7 +103,7 @@ public class ZUGFeRDExporter {
 
     //// MAIN CLASS
     private String conformanceLevel = "U";
-    private String versionStr = "1.2.0";
+    private String versionStr = "1.3.0";
 
     // BASIC, COMFORT etc - may be set from outside.
     private String ZUGFeRDConformanceLevel = null;

--- a/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
+++ b/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
@@ -149,6 +149,21 @@ public class MustangReaderWriterEdgeTest extends TestCase implements IZUGFeRDExp
         return "Zahlbar ohne Abzug bis zum " + germanDateFormat.format(getDueDate());
     }
 
+    @Override
+    public IZUGFeRDAllowanceCharge[] getZFAllowances() {
+        return null;
+    }
+
+    @Override
+    public IZUGFeRDAllowanceCharge[] getZFCharges() {
+        return null;
+    }
+
+    @Override
+    public IZUGFeRDAllowanceCharge[] getZFLogisticsServiceCharges() {
+        return null;
+    }
+
   class Contact implements IZUGFeRDExportableContact
   {
 

--- a/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
+++ b/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
@@ -251,6 +251,16 @@ public class MustangReaderWriterEdgeTest extends TestCase implements IZUGFeRDExp
       this.product = product;
     }
 
+    @Override
+    public IZUGFeRDAllowanceCharge[] getItemAllowances() {
+        return null;        
+    }
+
+    @Override
+    public IZUGFeRDAllowanceCharge[] getItemCharges() {
+        return null;
+    }
+
   }
 
   class Product implements IZUGFeRDExportableProduct

--- a/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
+++ b/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
@@ -148,6 +148,24 @@ public class MustangReaderWriterTest extends TestCase implements IZUGFeRDExporta
         return "Zahlbar ohne Abzug bis zum " + germanDateFormat.format(getDueDate());
     }
 
+    @Override
+    public IZUGFeRDAllowanceCharge[] getZFAllowances() {
+        return null;
+        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public IZUGFeRDAllowanceCharge[] getZFCharges() {
+        return null;
+        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public IZUGFeRDAllowanceCharge[] getZFLogisticsServiceCharges() {
+        return null;
+        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
   class Contact implements IZUGFeRDExportableContact
   {
 

--- a/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
+++ b/mustang/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
@@ -252,6 +252,16 @@ public class MustangReaderWriterTest extends TestCase implements IZUGFeRDExporta
     {
       this.product = product;
     }
+      
+    @Override
+    public IZUGFeRDAllowanceCharge[] getItemAllowances() {
+        return null;        
+    }
+
+    @Override
+    public IZUGFeRDAllowanceCharge[] getItemCharges() {
+        return null;
+    }    
 
   }
 

--- a/nbactions.xml
+++ b/nbactions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+        <action>
+            <actionName>CUSTOM-Generate mvn-repo</actionName>
+            <displayName>Generate mvn-repo</displayName>
+            <goals>
+                <goal>site:deploy</goal>
+            </goals>
+        </action>
+        <action>
+            <actionName>CUSTOM-mvn-repo</actionName>
+            <displayName>mvn-repo</displayName>
+            <goals>
+                <goal>site</goal>
+            </goals>
+        </action>
+        <action>
+            <actionName>CUSTOM-deploy</actionName>
+            <displayName>deploy</displayName>
+            <goals>
+                <goal>deploy</goal>
+            </goals>
+        </action>
+    </actions>

--- a/pdfa3-sample/pom.xml
+++ b/pdfa3-sample/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.rayman2200</groupId>
     <artifactId>mustang-sample-project</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
 	<artifactId>pdfa3-samples</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.rayman2200</groupId>
 	<artifactId>mustang-sample-project</artifactId>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<scm>
-		<connection>scm:git:https://github.com/Rayman2200/PDFA3.git</connection>
-		<developerConnection>scm:git:https://github.com/Rayman2200/PDFA3.git</developerConnection>
-		<url>https://github.com/Rayman2200/PDFA3</url>
+		<connection>scm:git:https://github.com/AlexanderSchmidt/PDFA3.git</connection>
+		<developerConnection>scm:git:https://github.com/AlexanderSchmidt/PDFA3.git</developerConnection>
+		<url>https://github.com/AlexanderSchmidt/PDFA3.git</url>
 		<tag>HEAD</tag>
 	</scm>
 
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>pdfbox</artifactId>
-			<version>1.8.8</version>
+			<version>1.8.10</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -77,7 +77,7 @@
 					</includes>
 					<merge>true</merge>
 					<repositoryName>PDFA3</repositoryName>      <!-- github repo name -->
-					<repositoryOwner>Rayman2200</repositoryOwner>    <!-- github username -->
+					<repositoryOwner>AlexanderSchmidt</repositoryOwner>    <!-- github username -->
 				</configuration>
 				<executions>
 					<!-- run site-maven-plugin's 'site' target as part of the build's normal 


### PR DESCRIPTION
- Fixed validation error due to missing tax category field
- Fixed decimal places for all amount / price fields
- Updated to PDFBOX 1.8.10
- Implemented support for Header and Item allowances / charges and service charges.
  - Introduced new interface IZUGFeRDAllowanceCharge for allowance and charges on all levels
  - added getZFAllowances(), getZFCharges() and getZFLogisticsServiceCharges() functions to Interface IZUGFeRDExportableTransaction -> can be null
  - added getItemAllowances() and getItemCharges() functions to Interface IZUGFeRDExportableItem -> can be null
- Improved totals calculation -> precalculated totals to reduce item loops